### PR TITLE
Expose selector dependencies for testing purposes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
     })
 
     selector.resultFunc = resultFunc
+    selector.dependencies = dependencies
     selector.recomputations = () => recomputations
     selector.resetRecomputations = () => recomputations = 0
     return selector

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -414,4 +414,18 @@ suite('selector', () => {
     )
     assert.equal(selector.resultFunc, lastFunction)
   })
+  test('export dependencies as dependencies', () => {
+    const dependency1 = (state) => { state.a }
+    const dependency2 = (state) => { state.a }
+
+    const selector = createSelector(
+      dependency1,
+      dependency2,
+      () => {}
+    )
+    assert.deepEqual(selector.dependencies, [
+      dependency1,
+      dependency2
+    ])
+  })
 })


### PR DESCRIPTION
This PR allows us to test which dependencies are passed into a selector.

Original conversation: https://github.com/reactjs/reselect/issues/76#issuecomment-299194186

**It matters which dependencies a selector uses**.  For example, if we have two selectors that use the same `resultFunc`...

```es6
const lookUp = (hash, ids) => ids.map((id) => hash[id]);

const getMyValues = createSelector(
  getMyHash,
  getMyIds,
  lookUp,
);

const getYourValues = createSelector(
  getYourHash,
  getYourIds,
  lookUp,
);
```

...testing the `resultFunc` isn't enough.  We actually need to test that the first two functions are what we expect them to be.  We can do this with an integration test (passing in the entire state into the whole selector) but, it forces us to essentially re-test `getMyHash`, `getMyIds`.

### Desired API
We've been running into this problem.  The direction I'm leaning is to expose the dependencies so that we can test them with a simple equality check.

```es6
it('uses the dependencies we expect', () => {
  // We can expose `dependencies`
  const dependencies = getMyValues.dependencies;

  expect(dependencies).to.deep.equal([
    getMyHash,
    getMyIds,
  ]);
});
```
