### PR TITLE
Selector with props in result func

### DIFF
--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -217,6 +217,15 @@ suite('selector', () => {
     assert.equal(selector2(state2, { x: 100, y: 201 }), 303)
     assert.equal(selector2.recomputations(), 2)
   })
+  test('selector with props in result func', () => {
+    const selector1 = state1 => state1.data
+    const selector2 = createSelector(
+      selector1,
+      (data, props) => data[props.key]
+    )
+    const state = { data: { foo: 'bar' } }
+    assert.equal(selector2(state, { key: 'foo' }), 'bar')
+  })
   test('chained selector with variadic args', () => {
     const selector1 = createSelector(
       state => state.sub,

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -219,8 +219,10 @@ suite('selector', () => {
   })
   test('selector with props in result func', () => {
     const selector1 = state1 => state1.data
+    const selectProps = (state, props) => props
     const selector2 = createSelector(
       selector1,
+      selectProps,
       (data, props) => data[props.key]
     )
     const state = { data: { foo: 'bar' } }


### PR DESCRIPTION
If you have a state that looks like this:

```javascript
const state = {
  data: {
    books: {
      recipes: {
        '123': { title: 'How To Make Apple Pie' }
      }
    }
  }
}
```

And you want a selector function

```javascript
getRecipe(state, '123'); // { title: 'How To Make Apple Pie' }
```

Such a selector would make sense to build by composing selectors:

```javascript
const books = state => state.data.books;
const recipes = createSelector(books, books => books.recipes);
const getRecipe = createSelector(recipes, (recipes, id) => recipes[id]);
```

However, with today's code, the `props` argument (which in this case would be the recipe id) will only be sent to the dependencies, and not to the result func. It would be nice if we could access the props in the result func as well, so that the example code above works.

I attached a unit test which should demonstrate it (the unit test fails because the feature is not implemented.)

Is this something that can be added to reselect?