### PR TITLE
added typings for dynamic array of uniform selectors

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -952,6 +952,15 @@ export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, S12
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
 ): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11 & P12, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
 
+/* any number of uniform selectors */
+export function createSelector<S, R, T>(
+  selectors: Selector<S, R>[],
+  combiner: (...res: R[]) => T,
+): OutputSelector<S, T, (...res: R[]) => T>;
+export function createSelector<S, P, R, T>(
+  selectors: ParametricSelector<S, P, R>[],
+  combiner: (...res: R[]) => T,
+): OutputParametricSelector<S, P, T, (...res: R[]) => T>;
 
 export function defaultMemoize<F extends Function>(
   func: F, equalityCheck?: <T>(a: T, b: T, index: number) => boolean,

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -466,3 +466,26 @@ function testCreateStructuredSelector() {
     baz: state => state.foo
   });
 }
+
+function testDynamicArrayArgument() {
+  interface Elem {
+    val1: string;
+    val2: string;
+  }
+  const data: ReadonlyArray<Elem> = [{val1: 'a', val2: 'aa'}, {val1: 'b', val2: 'bb'}];
+
+  createSelector(data.map(obj => () => obj.val1), (...vals) => vals.join(','));
+
+  // typings:expect-error
+  createSelector(data.map(obj => () => obj.val1), (vals) => vals.join(','))
+
+  createSelector(data.map(obj => () => obj.val1), (...vals: string[]) => 0)
+  // typings:expect-error
+  createSelector(data.map(obj => () => obj.val1), (...vals: number[]) => 0)
+
+  const s = createSelector(data.map(obj => (state: {}, fld: keyof Elem) => obj[fld]), (...vals) => vals.join(','));
+  s({}, 'val1');
+  s({}, 'val2');
+  // typings:expect-error
+  s({}, 'val3');
+}


### PR DESCRIPTION
Currently array version of `createSelector` typing has fixed number of selectors known at compile-time. However `createSelector`'s implementation supports any number of selectors determined at run-time. Technically input selectors can have different return types. That's impossible to describe in TypeScript. But it's possible to describe the case when all selectors have same return type. For example when input selectors are generated for each element of a container that has nr of elements  fixed during selector's lifetime:
```ts
createSelector(containerWithFixedNrOfElements.map(obj => () => obj.value), (...values) => expensiveCalculation(values))
```