### PR TITLE
add memoizedResultFunc to output selector interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,7 @@ export as namespace Reselect;
 export type Selector<S, R> = (state: S) => R;
 
 export type OutputSelector<S, R, C> = Selector<S, R> & {
+  memoizedResultFunc: C;
   resultFunc: C;
   recomputations: () => number;
   resetRecomputations: () => number;
@@ -11,6 +12,7 @@ export type OutputSelector<S, R, C> = Selector<S, R> & {
 export type ParametricSelector<S, P, R> = (state: S, props: P, ...args: any[]) => R;
 
 export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> & {
+  memoizedResultFunc: C;
   resultFunc: C;
   recomputations: () => number;
   resetRecomputations: () => number;

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
       return memoizedResultFunc.apply(null, params)
     })
 
+    selector.memoizedResultFunc = memoizedResultFunc
     selector.resultFunc = resultFunc
     selector.recomputations = () => recomputations
     selector.resetRecomputations = () => recomputations = 0


### PR DESCRIPTION
Exposes the `memoizedResultFunc` on the output selector so that (for example) you can access the cache (for example to clear it) when using `lodash.memoize` as is done in [this example](https://github.com/reduxjs/reselect#use-memoize-function-from-lodash-for-an-unbounded-cache).

I see that https://github.com/reduxjs/reselect/pull/220 exists, but it renames the exposed field to `memoize` which is rather misleading.  Also, it hasn't been touched for a while, so i dont know what the status is there.