### PR TITLE
Use provided memoize options in outer memoize call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,18 +65,21 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
     )
 
     // If a selector is called with the exact same arguments we don't need to traverse our dependencies again.
-    const selector = memoize(function () {
-      const params = []
-      const length = dependencies.length
+    const selector = memoize(
+      function () {
+        const params = []
+        const length = dependencies.length
 
-      for (let i = 0; i < length; i++) {
-        // apply arguments instead of spreading and mutate a local list of params for performance.
-        params.push(dependencies[i].apply(null, arguments))
-      }
+        for (let i = 0; i < length; i++) {
+          // apply arguments instead of spreading and mutate a local list of params for performance.
+          params.push(dependencies[i].apply(null, arguments))
+        }
 
-      // apply arguments instead of spreading for performance.
-      return memoizedResultFunc.apply(null, params)
-    })
+        // apply arguments instead of spreading for performance.
+        return memoizedResultFunc.apply(null, params)
+      },
+      ...memoizeOptions
+    )
 
     selector.resultFunc = resultFunc
     selector.dependencies = dependencies

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -247,10 +247,12 @@ suite('selector', () => {
       a => a
     )
     assert.equal(selector({ a: 1 }), 1)
-    assert.equal(selector({ a: 2 }), 1) // yes, really true
+    // still returns `1` since `typeof state` is still "object"
+    assert.equal(selector({ a: 2 }), 1)
     assert.equal(selector.recomputations(), 1)
-    assert.equal(selector({ a: 'A' }), 'A')
-    assert.equal(selector.recomputations(), 2)
+    // again returns `1` since `typeof state` is still "object"
+    assert.equal(selector({ a: 'A' }), 1)
+    assert.equal(selector.recomputations(), 1)
   })
   test('custom memoize', () => {
     const hashFn = (...args) => args.reduce((acc, val) => acc + '-' + JSON.stringify(val))


### PR DESCRIPTION
There are two memoize calls in `createSelectorCreator`.  One is to memoize the so called `resultFunc`.  The other memoize allows us to skip out early if the resulting selector is called with the exact same arguments.  

Currently, this second memoize uses the caller's provided `memoize` implementation, but does not pass the caller's `memoizeOptions`.  This PR changes it to pass the `memoizeOptions`.