### PR TITLE
Correct defaultEqualityCheck example arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ const totalSelector = createSelector(
 `defaultMemoize` determines if an argument has changed by calling the `equalityCheck` function. As `defaultMemoize` is designed to be used with immutable data, the default `equalityCheck` function checks for changes using reference equality:
 
 ```js
-function defaultEqualityCheck(currentVal, previousVal) {
+function defaultEqualityCheck(previousVal, currentVal) {
   return currentVal === previousVal
 }
 ```

--- a/README_RU.md
+++ b/README_RU.md
@@ -449,7 +449,7 @@ const totalSelector = createSelector(
 `defaultMemoize` определяет, изменился ли аргумент, вызывая функцию `equalityCheck`. Поскольку `defaultMemoize` предназначен для использования с неизменяемыми данными, функция по умолчанию `equalityCheck` проверяет наличие изменений с использованием строгого равенства:
 
 ```js
-function defaultEqualityCheck(currentVal, previousVal) {
+function defaultEqualityCheck(previousVal, currentVal) {
   return currentVal === previousVal;
 }
 ```


### PR DESCRIPTION
This PR corrects the order of the arguments for `defaultEqualityCheck` in the documentation.
The `equalityCheck` function is called as such in the code:
```js
const length = prev.length
for (let i = 0; i < length; i++) {
  if (!equalityCheck(prev[i], next[i])) {
    return false
  }
}
```
while `defaultEqualityCheck` in the README is specified as:
```js
function defaultEqualityCheck(currentVal, previousVal) {
  return currentVal === previousVal
}
```