### PR TITLE
Fix createStructuredSelector() example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,11 +562,9 @@ const mySelectorB = state => state.b
 const structuredSelector = createSelector(
    mySelectorA,
    mySelectorB,
-   mySelectorC,
-   (a, b, c) => ({
+   (a, b) => ({
      a,
-     b,
-     c
+     b
    })
 )
 ```


### PR DESCRIPTION
The `createSelector()` version of the `createStructuredSelector()` example uses a third, undeclared input-selector. This pull request removes `mySelectorC` and `c` which don't appear in the second snippet.