### PR TITLE
TypeScript: fix issue with `createSelector` overload order

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,16 +29,16 @@ export function createSelector<S, P, R1, T>(
 ): OutputParametricSelector<S, P, T, (res: R1) => T>;
 
 /* two selectors */
-export function createSelector<S, R1, R2, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  combiner: (res1: R1, res2: R2) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2) => T>;
 export function createSelector<S, P, R1, R2, T>(
   selector1: ParametricSelector<S, P, R1>,
   selector2: ParametricSelector<S, P, R2>,
   combiner: (res1: R1, res2: R2) => T,
 ): OutputParametricSelector<S, P, T, (res1: R1, res2: R2) => T>;
+export function createSelector<S, R1, R2, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  combiner: (res1: R1, res2: R2) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2) => T>;
 
 /* three selectors */
 export function createSelector<S, R1, R2, R3, T>(

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -219,6 +219,13 @@ function testParametricSelector() {
   );
 
   selector2({foo: 'fizz'}, {bar: 42});
+
+  // props type should be inferred from first input selector
+  const selector3 = createSelector(
+    (state, props: Props) => 1,
+    (state, props) => props.bar,
+    (foo, bar) => ({foo, bar}),
+  );
 }
 
 function testArrayArgument() {


### PR DESCRIPTION
See the test I added which was failing before this change.

I can't decide whether or not the overloads should have worked in their previous order. I've filed a TS bug here just to check: https://github.com/Microsoft/TypeScript/issues/30369.