### PR TITLE
remove the condition of next === null in the function areArgumentsShallowlyEqual

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ function defaultEqualityCheck(a, b) {
 }
 
 function areArgumentsShallowlyEqual(equalityCheck, prev, next) {
-  if (prev === null || next === null || prev.length !== next.length) {
+  if (prev === null || prev.length !== next.length) {
     return false
   }
 


### PR DESCRIPTION
I don't think it's meaningful to judge next=== null here. What's passed here is arguments!== null.