### PR TITLE
Expose selector's result to allow adhoc caching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ function getDependencies(funcs) {
 
 export function createSelectorCreator(memoize, ...memoizeOptions) {
   return (...funcs) => {
+    let lastResult
     let recomputations = 0
     const resultFunc = funcs.pop()
     const dependencies = getDependencies(funcs)
@@ -75,11 +76,13 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
       }
 
       // apply arguments instead of spreading for performance.
-      return memoizedResultFunc.apply(null, params)
+      lastResult = memoizedResultFunc.apply(null, params);
+      return lastResult;
     })
 
     selector.resultFunc = resultFunc
     selector.dependencies = dependencies
+    selector.lastResult = () => lastResult
     selector.recomputations = () => recomputations
     selector.resetRecomputations = () => recomputations = 0
     return selector


### PR DESCRIPTION
When a selector returns a complex value it can be difficult to get caching right. This will expose a way for selectors to see their own previous result which provides a way for users to do things like return the previous result if the result of the current call will be shallowly equal to previous result.

See #441 for an example of the feature request. Here is how this change would facilitate the solution:

```js
import { createSelector } from 'reselect';
import { shallowEqualArrays } from 'shallow-equal';

const currentUsersPosts = createSelector(
  [state => state.currentUser.id, state=> state.posts],
  (userId, posts) => {
    const result = posts.filter(p=>p.id === userId);
    const lastResult = currentUsersPosts.lastResult();
    if (shallowEqualArrays(lastResult, result)) return lastResult;
    return result;
  }
);
```