### PR TITLE
Add `resultCheckMemoize`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,22 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
   }
 }
 
+export function resultCheckMemoize(func, equalityCheck = defaultEqualityCheck, resultCheck = defaultEqualityCheck) {
+  let lastArgs = null
+  let lastResult = null
+  // we reference arguments instead of spreading them for performance reasons
+  return function () {
+    if (areArgumentsShallowlyEqual(equalityCheck, lastArgs, arguments)) {
+      // apply arguments instead of spreading for performance.
+      return lastResult
+    }
+
+    lastArgs = arguments
+    const result = func.apply(null, arguments)
+    return resultCheck(lastResult, result) ? lastResult : (lastResult = result)
+  }
+}
+
 function getDependencies(funcs) {
   const dependencies = Array.isArray(funcs[0]) ? funcs[0] : funcs
 

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -1,7 +1,7 @@
 // TODO: Add test for React Redux connect function
 
 import chai from 'chai'
-import {  createSelector, createSelectorCreator, defaultMemoize, createStructuredSelector  } from '../src/index'
+import {  createSelector, createSelectorCreator, defaultMemoize, createStructuredSelector, resultCheckMemoize  } from '../src/index'
 import {  default as lodashMemoize  } from 'lodash.memoize'
 
 const assert = chai.assert
@@ -273,6 +273,21 @@ suite('selector', () => {
     assert.equal(selector({ a: 2, b: 3 }), 5)
     assert.equal(selector.recomputations(), 3)
     // TODO: Check correct memoize function was called
+  })
+  test('custom memoize using `resultCheckMemoize`', () => {
+    const customSelectorCreator = createSelectorCreator(
+      resultCheckMemoize,
+      undefined,
+      (a, b) => JSON.stringify(a) === JSON.stringify(b)
+    )
+    const selector = customSelectorCreator(
+      state => state.users,
+      users => Object.keys(users)
+    )
+    const result = selector({ users: { a: {}, b: {} } })
+    assert.deepEqual(result, [ 'a', 'b' ])
+    assert.equal(selector({ users: { a: {}, b: {} } }), result)
+    assert.equal(selector.recomputations(), 2)
   })
   test('exported memoize', () => {
     let called = 0


### PR DESCRIPTION
Closes https://github.com/reduxjs/reselect/issues/451

Idea copied from https://github.com/reduxjs/reselect/issues/74

For now I just copied the ideas discussed in https://github.com/reduxjs/reselect/issues/74.

Alternatively, instead of adding another memoize function, we could modify `defaultMemoize` so it can also receive a `resultCheck` parameter.