### PR TITLE
docs: Fix arguments order in description of `defaultEqualityChec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ const totalSelector = createSelector(
 `defaultMemoize` determines if an argument has changed by calling the `equalityCheck` function. As `defaultMemoize` is designed to be used with immutable data, the default `equalityCheck` function checks for changes using reference equality:
 
 ```js
-function defaultEqualityCheck(currentVal, previousVal) {
+function defaultEqualityCheck(previousVal, currentVal) {
   return currentVal === previousVal
 }
 ```

--- a/README_RU.md
+++ b/README_RU.md
@@ -449,7 +449,7 @@ const totalSelector = createSelector(
 `defaultMemoize` определяет, изменился ли аргумент, вызывая функцию `equalityCheck`. Поскольку `defaultMemoize` предназначен для использования с неизменяемыми данными, функция по умолчанию `equalityCheck` проверяет наличие изменений с использованием строгого равенства:
 
 ```js
-function defaultEqualityCheck(currentVal, previousVal) {
+function defaultEqualityCheck(previousVal, currentVal) {
   return currentVal === previousVal;
 }
 ```


### PR DESCRIPTION
Fix arguments order in description of `defaultEqualityCheck` function.

Fix: https://github.com/reduxjs/reselect/issues/466