### PR TITLE
Make OutputSelector backwards compatible w/ < 4.1.0 version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,9 +168,9 @@ interface CreateSelectorFunction<
   ): OutputSelector<
     Selectors,
     Result,
-    GetParamsFromSelectors<Selectors>,
     ((...args: SelectorResultArray<Selectors>) => Result) &
-      ReturnType<MemoizeFunction>
+      ReturnType<MemoizeFunction>,
+    GetParamsFromSelectors<Selectors>
   >
 
   /** Input selectors as separate inline arguments with memoizeOptions passed */
@@ -183,9 +183,9 @@ interface CreateSelectorFunction<
   ): OutputSelector<
     Selectors,
     Result,
-    GetParamsFromSelectors<Selectors>,
     ((...args: SelectorResultArray<Selectors>) => Result) &
-      ReturnType<MemoizeFunction>
+      ReturnType<MemoizeFunction>,
+    GetParamsFromSelectors<Selectors>
   >
 
   /** Input selectors as a separate array */
@@ -196,9 +196,9 @@ interface CreateSelectorFunction<
   ): OutputSelector<
     Selectors,
     Result,
-    GetParamsFromSelectors<Selectors>,
     ((...args: SelectorResultArray<Selectors>) => Result) &
-      ReturnType<MemoizeFunction>
+      ReturnType<MemoizeFunction>,
+    GetParamsFromSelectors<Selectors>
   >
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,8 @@ interface OutputSelectorFields<Combiner, Result> {
 export type OutputSelector<
   S extends SelectorArray,
   Result,
-  Params extends readonly any[],
-  Combiner
+  Combiner,
+  Params extends readonly any[] = never
 > = Selector<GetStateFromSelectors<S>, Result, Params> &
   OutputSelectorFields<Combiner, Result>
 


### PR DESCRIPTION
This would make the `OutputSelector` backward compatible with the pre-4.1.0 version.

See comment https://github.com/reduxjs/reselect/issues/533#issuecomment-957963101