### PR TITLE
Export CreateSelectorFunction to fix createStructuredSelector usage

### DIFF
--- a/.github/workflows/build-and-test-types.yml
+++ b/.github/workflows/build-and-test-types.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['14.x']
-        ts: ['4.2', '4.3', '4.4', 'next']
+        ts: ['4.2', '4.3', '4.4', '4.5', 'next']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,14 +151,14 @@ export function createSelectorCreator<
   >
 }
 
-interface CreateSelectorOptions<MemoizeOptions extends unknown[]> {
+export interface CreateSelectorOptions<MemoizeOptions extends unknown[]> {
   memoizeOptions: MemoizeOptions[0] | MemoizeOptions
 }
 
 /**
  * An instance of createSelector, customized with a given memoize implementation
  */
-interface CreateSelectorFunction<
+export interface CreateSelectorFunction<
   F extends (...args: unknown[]) => unknown,
   MemoizeFunction extends (func: F, ...options: any[]) => F,
   MemoizeOptions extends unknown[] = DropFirst<Parameters<MemoizeFunction>>,

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -66,6 +66,18 @@ interface StateSub {
   }
 }
 
+// Test exporting
+export const testExportBasic = createSelector(
+  (state: StateA) => state.a,
+  a => a
+)
+
+// Test for exporting declaration of created selector creator
+export const testExportStructured = createSelectorCreator(
+  defaultMemoize,
+  (a, b) => typeof a === typeof b
+)
+
 function testSelector() {
   type State = { foo: string }
 

--- a/typescript_test/tsconfig.json
+++ b/typescript_test/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "strict": true,
-    "target": "ES2015"
+    "target": "ES2015",
+    "declaration": true,
+    "noEmit": true
   },
   "include": ["test.ts"]
 }


### PR DESCRIPTION
This PR:

- Exports the `CreateSelectorFunction` type, because apparently exports using `createStructuredSelector` were broken without it.
- Adds TS 4.5 to the test matrix

Supersedes #553 .