### PR TITLE
Make it an error if optional types are inconsistent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,16 +167,16 @@ export interface CreateSelectorFunction<
   >
 > {
   /** Input selectors as separate inline arguments */
-  <Selectors extends SelectorArray, Result>(
+  <Selectors extends SelectorArray, Result, Params extends readonly any[] = GetParamsFromSelectors<Selectors>>(
     ...items: [
       ...Selectors,
       (...args: SelectorResultArray<Selectors>) => Result
     ]
-  ): OutputSelector<
+  ): Params extends [never] ? never : OutputSelector<
     Selectors,
     Result,
     (...args: SelectorResultArray<Selectors>) => Result & Keys,
-    GetParamsFromSelectors<Selectors>
+    Params
   > &
     Keys
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,10 +92,7 @@ export type GetStateFromSelectors<S extends SelectorArray> =
 export type GetParamsFromSelectors<
   S extends SelectorArray,
   RemainingItems extends readonly unknown[] = Tail<MergeParameters<S>>
-  // This seems to default to an array containing an empty object, which is
-  // not meaningful and causes problems with the `Selector/OutputSelector` types.
-  // Force it to have a meaningful value, or cancel it out.
-> = RemainingItems extends [EmptyObject] ? never : RemainingItems
+> = RemainingItems
 
 /** Given a set of input selectors, extracts the intersected parameters to determine
  * what values can actually be passed to all of the input selectors at once

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -610,9 +610,8 @@ function testOptionalArgumentsConflicting() {
     (str) => str
   )
 
-  // @ts-expect-error This should be an error because prefix is required, although it is any
+  // @ts-expect-error
   selector2({} as State)
-  // @ts-expect-error Ideally this is not an error, so this expect-error is a bug
   selector2({} as State, 'blach')
 
   const selector3 = createSelector(


### PR DESCRIPTION
Improves things for #563

Honestly this PR is mostly to demonstrate the problem and what could be done.. I tried more fundamental changes but someone who knows the codebase better would need to try. I didn't understand why Selectors default to `never` and then switch between having args or not. as per this playground

https://www.typescriptlang.org/play?#code/MYewdgzgLgBAhjAvDAFASiQPhgbwL4CwAUKJLAEZKoB0tcATgOYQBcMA2gLoaLb7HE4KAORQAptGFoA3MXIjxkmUA

if the args are typed as empty tuple e.g.  `[]` then typescript will enforce that no params are passed. Can't we default to empty arrays?

I believe that would be the only change required and would probably reduce complexity and code as a tuple containing never will not allow 0 or 1 arguments.

https://www.typescriptlang.org/play?#code/MYewdgzgLgBAhjAvDAFASiQPhgbwL4CwAUKJLAEZKoB0tcATgOYQBcMA2mAKYBuX9AXQyJs+YsTgoA5FC7QpaANzFy02fKUr0ioA
