### PR TITLE
Improve error when handling a circular dependency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,9 +46,13 @@ function getDependencies(funcs: unknown[]) {
       )
       .join(', ')
 
-    throw new Error(
-      `createSelector expects all input-selectors to be functions, but received the following types: [${dependencyTypes}]`
-    )
+    let error = `createSelector expects all input-selectors to be functions, but received the following types: [${dependencyTypes}].`
+    if (dependencyTypes.includes('undefined')) {
+      error +=
+        'This is likely the result of a circulate dependency in your selector files.'
+    }
+
+    throw new Error(error)
   }
 
   return dependencies as SelectorArray


### PR DESCRIPTION
This PR improves the error messaging in getDependencies so it alerts the user if the issue is likely due to a circular dependency.