### PR TITLE
Infer correct state when input selectors are a mix of explicit and rest syntax in createSelector

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { MergeParameters } from './versionedTypes'
+import type { MergeParameters, ExtractParams } from './versionedTypes'
 export type { MergeParameters } from './versionedTypes'
 
 /*
@@ -89,9 +89,13 @@ export type EqualityFn = (a: any, b: any) => boolean
 export type SelectorResultArray<Selectors extends SelectorArray> =
   ExtractReturnType<Selectors>
 
+/** Finds union of the first parameter from an array of functions and turns it into an intersection */
+type GetIntersectedFirstParam<T extends readonly UnknownFunction[]> =
+  UnionToIntersection<ExtractParams<T>[number][0]>
+
 /** Determines the combined single "State" type (first arg) from all input selectors */
 export type GetStateFromSelectors<S extends SelectorArray> =
-  MergeParameters<S>[0]
+  GetIntersectedFirstParam<S>
 
 /** Determines the combined  "Params" type (all remaining args) from all input selectors */
 export type GetParamsFromSelectors<

--- a/src/versionedTypes/index.ts
+++ b/src/versionedTypes/index.ts
@@ -1,1 +1,1 @@
-export { MergeParameters } from './ts47-mergeParameters'
+export { MergeParameters, ExtractParams } from './ts47-mergeParameters'

--- a/src/versionedTypes/index.ts
+++ b/src/versionedTypes/index.ts
@@ -1,1 +1,1 @@
-export { MergeParameters, ExtractParams } from './ts47-mergeParameters'
+export { MergeParameters } from './ts47-mergeParameters'

--- a/src/versionedTypes/ts47-mergeParameters.ts
+++ b/src/versionedTypes/ts47-mergeParameters.ts
@@ -34,11 +34,9 @@ type MergeTuples<
   [K in keyof L]: Intersect<ElementsAt<T, K>>
 }
 
-type ExtractParameters<T extends readonly UnknownFunction[]> = {
+export type ExtractParams<T extends readonly UnknownFunction[]> = {
   [K in keyof T]: Parameters<T[K]>
 }
 
 export type MergeParameters<T extends readonly UnknownFunction[]> =
-  '0' extends keyof T
-    ? MergeTuples<ExtractParameters<T>>
-    : Parameters<T[number]>
+  '0' extends keyof T ? MergeTuples<ExtractParams<T>> : Parameters<T[number]>

--- a/src/versionedTypes/ts47-mergeParameters.ts
+++ b/src/versionedTypes/ts47-mergeParameters.ts
@@ -1,11 +1,11 @@
 // This entire implementation courtesy of Anders Hjelsberg:
 // https://github.com/microsoft/TypeScript/pull/50831#issuecomment-1253830522
 
+import { ReverseHead, ReverseTail } from '../types'
+
 type UnknownFunction = (...args: any[]) => any
 
-type LongestTuple<T extends readonly unknown[][]> = T extends [
-  infer U extends unknown[]
-]
+type LongestTuple<T> = T extends [infer U extends unknown[]]
   ? U
   : T extends [infer U, ...infer R extends unknown[][]]
   ? MostProperties<U, LongestTuple<R>>
@@ -13,11 +13,9 @@ type LongestTuple<T extends readonly unknown[][]> = T extends [
 
 type MostProperties<T, U> = keyof U extends keyof T ? T : U
 
-type ElementAt<T extends unknown[], N extends keyof any> = N extends keyof T
-  ? T[N]
-  : unknown
+type ElementAt<T, N extends keyof any> = N extends keyof T ? T[N] : unknown
 
-type ElementsAt<T extends readonly unknown[][], N extends keyof any> = {
+type ElementsAt<T, N extends keyof any> = {
   [K in keyof T]: ElementAt<T[K], N>
 }
 
@@ -27,16 +25,42 @@ type Intersect<T extends readonly unknown[]> = T extends []
   ? H & Intersect<T>
   : T[number]
 
-type MergeTuples<
-  T extends readonly unknown[][],
-  L extends unknown[] = LongestTuple<T>
-> = {
-  [K in keyof L]: Intersect<ElementsAt<T, K>>
+type MergeTuples<T, L extends unknown[] = LongestTuple<T>> = {
+  [K in keyof L]: Intersect<
+    ElementsAt<T, K> extends readonly unknown[] ? ElementsAt<T, K> : never
+  >
 }
 
-export type ExtractParams<T extends readonly UnknownFunction[]> = {
+type ExtractParameters<T extends readonly UnknownFunction[]> = {
   [K in keyof T]: Parameters<T[K]>
 }
 
 export type MergeParameters<T extends readonly UnknownFunction[]> =
-  '0' extends keyof T ? MergeTuples<ExtractParams<T>> : Parameters<T[number]>
+  '0' extends keyof T
+    ? MergeTuples<MakeRestExplicit<ExtractParameters<T>>>
+    : Parameters<T[number]>
+
+type HasRest<S extends readonly unknown[]> = number extends S['length']
+  ? true
+  : false
+
+type HasExplicit<S extends readonly unknown[]> = '0' extends keyof S
+  ? true
+  : false
+
+type HasCombined<S extends readonly unknown[]> = true extends HasExplicit<S> &
+  HasRest<S>
+  ? true
+  : false
+
+type MakeRestExplicit<T extends readonly unknown[][]> =
+  true extends HasCombined<T>
+    ? [
+        ...ReverseTail<T>,
+        ReverseHead<T> extends readonly unknown[]
+          ? ReverseHead<T>[number]
+          : never
+      ]
+    : true extends HasRest<T>
+    ? [...T]
+    : T

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -1672,14 +1672,9 @@ function issue601() {
     bar: string
   }
 
-  interface IState2 {
-    bar: string
-    baz: number
-  }
-
   const selectFoo = (state: IState) => state.foo
   // Includes params in selector to be sure that this does not ruin inference
-  const selectBar = (state: IState2, params: { a: number }) => state.bar
+  const selectBar = (state: IState, params: { a: number }) => state.bar
 
   const selectors = [selectFoo, selectBar]
 
@@ -1698,9 +1693,9 @@ function issue601() {
     }
   )
 
-  selectFooBar({ bar: 'bar', baz: 2, foo: 3 })
+  selectFooBar({ foo: 3, bar: 'bar' }, { a: 3 })
   // @ts-expect-error
-  const res: number = selectFooBar({ bar: 'bar', baz: 2, foo: 3 })
+  const res: number = selectFooBar({ foo: 3, bar: 'bar' })
   // @ts-expect-error
-  selectFooBar({ bar: 'bar', foo: 3 })
+  selectFooBar({ foo: 3, bar: 'bar' })
 }

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -1665,3 +1665,42 @@ function issue555() {
   const selectorResult2 = someSelector2(state, undefined)
   const selectorResult3 = someSelector3(state, null)
 }
+
+function issue601() {
+  interface IState {
+    foo: number
+    bar: string
+  }
+
+  interface IState2 {
+    bar: string
+    baz: number
+  }
+
+  const selectFoo = (state: IState) => state.foo
+  // Includes params in selector to be sure that this does not ruin inference
+  const selectBar = (state: IState2, params: { a: number }) => state.bar
+
+  const selectors = [selectFoo, selectBar]
+
+  const selectFooBar = createSelector(
+    [selectBar, selectFoo, ...selectors],
+    (foo, bar, ...rest) => {
+      rest.push('a')
+      rest.push(1)
+      // @ts-expect-error
+      rest.push(true)
+      // @ts-expect-error
+      const nFoo: number = foo
+      // @ts-expect-error
+      const nBar: string = bar
+      return 'foobar'
+    }
+  )
+
+  selectFooBar({ bar: 'bar', baz: 2, foo: 3 })
+  // @ts-expect-error
+  const res: number = selectFooBar({ bar: 'bar', baz: 2, foo: 3 })
+  // @ts-expect-error
+  selectFooBar({ bar: 'bar', foo: 3 })
+}


### PR DESCRIPTION
The state parameter of the result of createSelector was of type never if input selectors were a mix of explicit and spread selectors. Additionally, the type of extra parameters are lost if the input has this format.

This PR aims to allow the combining of explicitly defined input selectors and using rest syntax in the end. It does so by making sure that the type of the array that is part of the rest syntax is transformed into a normal type before merging the parameter tuples. This is valid since we really don't care whether we have 1 or 10 selectors in the array that is spread as long as the types are the same.

This is related to [issue 601](https://github.com/reduxjs/reselect/issues/601) where some more details can be found in the conversation.