### PR TITLE
Build browser ESM and Webpack 4 compat artifacts, and add sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0-alpha.1",
   "description": "Selectors for Redux.",
   "main": "./dist/cjs/reselect.cjs",
-  "module": "./dist/reselect.mjs",
+  "module": "./dist/reselect.legacy-esm.js",
   "types": "./dist/reselect.d.ts",
   "exports": {
     "./package.json": "./package.json",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,10 +18,12 @@ export default defineConfig(options => {
     entry: {
       reselect: 'src/index.ts'
     },
+    sourcemap: true,
     ...options
   }
 
   return [
+    // Modern ESM
     {
       ...commonOptions,
       format: ['esm'],
@@ -29,8 +31,6 @@ export default defineConfig(options => {
       dts: true,
       clean: true,
       async onSuccess() {
-        // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
-        fs.copyFileSync('dist/reselect.mjs', 'dist/reselect.legacy-esm.js')
         console.log('onSuccess')
 
         console.log('Generating TS 4.6 types...')
@@ -41,6 +41,31 @@ export default defineConfig(options => {
         )
         console.log('TS 4.6 types done')
       }
+    },
+
+    // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
+    // and optional chaining compiled away
+    {
+      ...commonOptions,
+      entry: {
+        'reselect.legacy-esm': 'src/index.ts'
+      },
+      format: ['esm'],
+      outExtension: () => ({ js: '.js' }),
+      target: 'es2017'
+    },
+    // Browser-ready ESM, production + minified
+    {
+      ...commonOptions,
+      entry: {
+        'reselect.browser': 'src/index.ts'
+      },
+      define: {
+        'process.env.NODE_ENV': JSON.stringify('production')
+      },
+      format: ['esm'],
+      outExtension: () => ({ js: '.mjs' }),
+      minify: true
     },
     {
       ...commonOptions,


### PR DESCRIPTION
This PR:

- Updates the build config to add a browser-compatible ESM production artifact that has `process.env.NODE_ENV` compiled away, and a real Webpack 4-compatible artifact with `?.` and `??` transpiled.