### PR TITLE
Record computation time

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,9 @@ export interface OutputSelectorFields<Combiner extends UnknownFunction, Keys> {
   dependencies: SelectorArray
   /** Counts the number of times the output has been recalculated */
   recomputations: () => number
-  /** Resets the count of recomputations count to 0 */
+  /** Total computation time of everytime the output has been recalculated */
+  computationTime: () => number
+  /** Resets the count of recomputations count and computation time to 0 */
   resetRecomputations: () => number
 }
 


### PR DESCRIPTION
Hi,

Currently, I'm using `recomputations` count to verify the performance of our selectors in local environment. This gave us a lot of insights into how we implemented the selectors. Besides the re-computation count, I'd like to know more about how long is the execution/computation time as well. Therefore I create this PR for this change. Hope it would be helpful for everyone.

Sorry if I didn’t follow any guidelines, this is the first time I submit PR.

Thank you.