### PR TITLE
Use default Node version in CI

### DIFF
--- a/.github/workflows/build-and-test-types.yml
+++ b/.github/workflows/build-and-test-types.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
 
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
 
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
 

--- a/.github/workflows/build-and-test-types.yml
+++ b/.github/workflows/build-and-test-types.yml
@@ -8,11 +8,8 @@ on:
 
 jobs:
   build:
-    name: Lint, Test, Report Coverage on Node ${{ matrix.node }}
+    name: Lint, Test, Report Coverage on Node
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: ['16.x']
 
     steps:
       - name: Checkout code
@@ -21,7 +18,6 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
           cache: 'yarn'
 
       - name: Install dependencies
@@ -56,16 +52,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16.x']
         ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Install deps
@@ -102,7 +96,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16.x']
         example:
           [
             'cra4',
@@ -117,10 +110,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Use node ${{ matrix.node }}
+      - name: Use node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
           cache: 'yarn'
 
       - name: Clone RTK repo


### PR DESCRIPTION
Deprecated Node versions are used in CI, potentially causing security and reliability issues. Instead, it's better to use GitHub's default Node version, which also doesn't require additional downloads or installations.