### PR TITLE
suggestion: add overload for "solo selector" without input selectors

### DIFF
--- a/src/createSelectorCreator.ts
+++ b/src/createSelectorCreator.ts
@@ -141,6 +141,32 @@ export interface CreateSelectorFunction<
     OverrideArgsMemoizeFunction
   > &
     InterruptRecursion
+
+    <
+    SoloSelector extends (...args: any[]) => any,
+    OverrideMemoizeFunction extends UnknownMemoizer = MemoizeFunction,
+    OverrideArgsMemoizeFunction extends UnknownMemoizer = ArgsMemoizeFunction
+  >(
+    selector: SoloSelector,
+    createSelectorOptions?: Simplify<
+      CreateSelectorOptions<
+        MemoizeFunction,
+        ArgsMemoizeFunction,
+        OverrideMemoizeFunction,
+        OverrideArgsMemoizeFunction
+      >
+    >
+  ): OutputSelector<
+    ParametersToVirtualInputSelectors<Parameters<SoloSelector>>,
+    ReturnType<SoloSelector>,
+    OverrideMemoizeFunction,
+    OverrideArgsMemoizeFunction
+  > &
+    InterruptRecursion
+}
+
+type ParametersToVirtualInputSelectors<T extends [...any]> = {
+  [K in keyof T]: K extends keyof Array<any> ? T[K] : (...params: T) => T[K]
 }
 
 let globalStabilityCheck: StabilityCheckFrequency = 'once'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,6 +110,11 @@ export function collectInputSelectorResults(
 ) {
   const inputSelectorResults = []
   const { length } = dependencies
+  if (!length) {
+    // no input selectors -> only one selector function was passed to `createSelector`
+    // pass all arguments to that selector function
+    return inputSelectorArgs
+  }
   for (let i = 0; i < length; i++) {
     // @ts-ignore
     // apply arguments instead of spreading and mutate a local list of params for performance.

--- a/test/reselect.spec.ts
+++ b/test/reselect.spec.ts
@@ -189,6 +189,11 @@ describe('Basic selector behavior', () => {
     expect(selector.recomputations()).toBe(2)
   })
 
+  test('only a result function is passed in, no input selectors', () => {
+    const selector = createSelector((a: string, b: number, c: string) => `${a}|${b}|${c}`)
+    expect(selector('foo', 3, 'baz')).toBe('foo|3|baz')
+  })
+
   test('can accept props', () => {
     let called = 0
     const selector = createSelector(


### PR DESCRIPTION
This is just something I wanted to explore.

Of course, people can always just call `defaultSelector`, but that's an additional function people have to be aware of, and it makes code bases less uniform. Right now, people oftentimes use identity functions, either as input selectors, or worse, even as result functions.

This would just allow a single function without input selectors to be memoized directly.