### PR TITLE
Match `resetRecomputations` and `resetDependencyRecomputations` behavior to their types

### DIFF
--- a/src/createSelectorCreator.ts
+++ b/src/createSelectorCreator.ts
@@ -444,10 +444,14 @@ export function createSelectorCreator<
       memoizedResultFunc,
       dependencies,
       dependencyRecomputations: () => dependencyRecomputations,
-      resetDependencyRecomputations: () => (dependencyRecomputations = 0),
+      resetDependencyRecomputations: () => {
+        dependencyRecomputations = 0
+      },
       lastResult: () => lastResult,
       recomputations: () => recomputations,
-      resetRecomputations: () => (recomputations = 0),
+      resetRecomputations: () => {
+        recomputations = 0
+      },
       memoize,
       argsMemoize
     }) as OutputSelector<

--- a/test/reselect.spec.ts
+++ b/test/reselect.spec.ts
@@ -872,10 +872,6 @@ describe('argsMemoize and memoize', () => {
     expect(selectorMicroMemoizeOverridden.dependencyRecomputations()).to.be.a(
       'number'
     )
-    expect(selectorMicroMemoizeOverridden.resetRecomputations()).toBe(0)
-    expect(selectorMicroMemoizeOverridden.resetDependencyRecomputations()).toBe(
-      0
-    )
     expect(
       selectorMicroMemoizeOverridden.resultFunc([
         {
@@ -954,12 +950,6 @@ describe('argsMemoize and memoize', () => {
       selectorMicroMemoizeOverrideArgsMemoizeOnly.dependencyRecomputations()
     ).to.be.a('number')
     expect(
-      selectorMicroMemoizeOverrideArgsMemoizeOnly.resetRecomputations()
-    ).toBe(0)
-    expect(
-      selectorMicroMemoizeOverrideArgsMemoizeOnly.resetDependencyRecomputations()
-    ).toBe(0)
-    expect(
       selectorMicroMemoizeOverrideArgsMemoizeOnly.resultFunc([
         {
           id: 0,
@@ -1031,12 +1021,6 @@ describe('argsMemoize and memoize', () => {
     expect(
       selectorMicroMemoizeOverrideMemoizeOnly.dependencyRecomputations()
     ).to.be.a('number')
-    expect(selectorMicroMemoizeOverrideMemoizeOnly.resetRecomputations()).toBe(
-      0
-    )
-    expect(
-      selectorMicroMemoizeOverrideMemoizeOnly.resetDependencyRecomputations()
-    ).toBe(0)
     expect(
       selectorMicroMemoizeOverrideMemoizeOnly.resultFunc([
         {


### PR DESCRIPTION
This PR:

- [X] Fixes `resetRecomputations` and `resetDependencyRecomputations` runtime behavior so that they return `void` instead of 0 which is the intended behavior.
- [X] Removes unit tests checking to see if these functions return 0. 