### PR TITLE
Fix `_lastResult.deref` is not a function (it is undefined) in React Native and Expo applications

### DIFF
--- a/src/weakMapMemoize.ts
+++ b/src/weakMapMemoize.ts
@@ -232,7 +232,7 @@ export function weakMapMemoize<Func extends AnyFunction>(
     terminatedNode.s = TERMINATED
 
     if (resultEqualityCheck) {
-      const lastResultValue = lastResult?.deref() ?? lastResult
+      const lastResultValue = lastResult?.deref?.() ?? lastResult
       if (
         lastResultValue != null &&
         resultEqualityCheck(lastResultValue as ReturnType<Func>, result)


### PR DESCRIPTION
This PR:

- [X] Fixes `_lastResult.deref` is not a function (it is undefined) in React Native and Expo applications
- [X] Fixes #669