### PR TITLE
Fix `expectExactType` to be compatible with TypeScript 5.4

### DIFF
--- a/typescript_test/typesTestUtils.ts
+++ b/typescript_test/typesTestUtils.ts
@@ -25,5 +25,5 @@ export type IsEqual<A, B> = (<G>() => G extends A ? 1 : 2) extends <
   : false
 
 export function expectExactType<T>(t: T) {
-  return <U extends Equals<T, U>>(u: U) => {}
+  return <U extends T>(u: U & Equals<T, U>) => {}
 }


### PR DESCRIPTION
This PR:

  - [X] Fixes `expectExactType` to be compatible with TypeScript 5.4 per reduxjs/react-redux#2123