### PR TITLE
Set target to es2019 on esm build

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -27,6 +27,7 @@ export default defineConfig(options => {
     {
       ...commonOptions,
       format: ['esm'],
+      target: 'es2019',
       outExtension: () => ({ js: '.mjs' }),
       dts: true,
       clean: true


### PR DESCRIPTION
Library do not work in Safari < 14.1

`Unexpected token '=' . Expected an opening '(' before a method's parameter list`

Setting the target to es2019 in the esm build will fix the problem for High Sierra to Catalina.