### PR TITLE
Ensure `lruMemoize` correctly memoizes when `maxSize` is set to a number less than 1

### DIFF
--- a/src/lruMemoize.ts
+++ b/src/lruMemoize.ts
@@ -205,7 +205,7 @@ export function lruMemoize<Func extends AnyFunction>(
   let resultsCount = 0
 
   const cache =
-    maxSize === 1
+    maxSize <= 1
       ? createSingletonCache(comparator)
       : createLruCache(maxSize, comparator)
 


### PR DESCRIPTION
This PR:

  - [X] Fixes an issue with `lruMemoize` that would cause memoization to completely break when `maxSize` is set to a value that is less than 1.
  - [X] Adds units tests to make sure the issue is effectively resolved.