### PR TITLE
Fix `resultEqualityCheck` behavior in `weakMapMemoize`

### DIFF
--- a/test/benchmarks/resultEqualityCheck.bench.ts
+++ b/test/benchmarks/resultEqualityCheck.bench.ts
@@ -1,0 +1,190 @@
+import type { AnyFunction } from '@internal/types'
+import type { OutputSelector, Selector } from 'reselect'
+import {
+  createSelector,
+  lruMemoize,
+  referenceEqualityCheck,
+  weakMapMemoize
+} from 'reselect'
+import type { Options } from 'tinybench'
+import { bench } from 'vitest'
+import {
+  logSelectorRecomputations,
+  setFunctionNames,
+  setupStore,
+  toggleCompleted,
+  type RootState
+} from '../testUtils'
+
+describe('memoize functions performance with resultEqualityCheck set to referenceEqualityCheck vs. without resultEqualityCheck', () => {
+  describe('comparing selectors created with createSelector', () => {
+    const store = setupStore()
+
+    const arrayOfNumbers = Array.from({ length: 1_000 }, (num, index) => index)
+
+    const commonOptions: Options = {
+      iterations: 10_000,
+      time: 0
+    }
+
+    const runSelector = <S extends Selector>(selector: S) => {
+      arrayOfNumbers.forEach(num => {
+        selector(store.getState())
+      })
+    }
+
+    const createAppSelector = createSelector.withTypes<RootState>()
+
+    const selectTodoIdsWeakMap = createAppSelector(
+      [state => state.todos],
+      todos => todos.map(({ id }) => id)
+    )
+
+    const selectTodoIdsWeakMapWithResultEqualityCheck = createAppSelector(
+      [state => state.todos],
+      todos => todos.map(({ id }) => id),
+      {
+        memoizeOptions: { resultEqualityCheck: referenceEqualityCheck },
+        argsMemoizeOptions: { resultEqualityCheck: referenceEqualityCheck }
+      }
+    )
+
+    const selectTodoIdsLru = createAppSelector(
+      [state => state.todos],
+      todos => todos.map(({ id }) => id),
+      { memoize: lruMemoize, argsMemoize: lruMemoize }
+    )
+
+    const selectTodoIdsLruWithResultEqualityCheck = createAppSelector(
+      [state => state.todos],
+      todos => todos.map(({ id }) => id),
+      {
+        memoize: lruMemoize,
+        memoizeOptions: { resultEqualityCheck: referenceEqualityCheck },
+        argsMemoize: lruMemoize,
+        argsMemoizeOptions: { resultEqualityCheck: referenceEqualityCheck }
+      }
+    )
+
+    const selectors = {
+      selectTodoIdsWeakMap,
+      selectTodoIdsWeakMapWithResultEqualityCheck,
+      selectTodoIdsLru,
+      selectTodoIdsLruWithResultEqualityCheck
+    }
+
+    setFunctionNames(selectors)
+
+    const createOptions = <S extends OutputSelector>(selector: S) => {
+      const options: Options = {
+        setup: (task, mode) => {
+          if (mode === 'warmup') return
+
+          task.opts = {
+            beforeEach: () => {
+              store.dispatch(toggleCompleted(1))
+            },
+
+            afterAll: () => {
+              logSelectorRecomputations(selector)
+            }
+          }
+        }
+      }
+      return { ...commonOptions, ...options }
+    }
+
+    Object.values(selectors).forEach(selector => {
+      bench(
+        selector,
+        () => {
+          runSelector(selector)
+        },
+        createOptions(selector)
+      )
+    })
+  })
+
+  describe('comparing selectors created with memoize functions', () => {
+    const store = setupStore()
+
+    const arrayOfNumbers = Array.from(
+      { length: 100_000 },
+      (num, index) => index
+    )
+
+    const commonOptions: Options = {
+      iterations: 1000,
+      time: 0
+    }
+
+    const runSelector = <S extends Selector>(selector: S) => {
+      arrayOfNumbers.forEach(num => {
+        selector(store.getState())
+      })
+    }
+
+    const selectTodoIdsWeakMap = weakMapMemoize((state: RootState) =>
+      state.todos.map(({ id }) => id)
+    )
+
+    const selectTodoIdsWeakMapWithResultEqualityCheck = weakMapMemoize(
+      (state: RootState) => state.todos.map(({ id }) => id),
+      { resultEqualityCheck: referenceEqualityCheck }
+    )
+
+    const selectTodoIdsLru = lruMemoize((state: RootState) =>
+      state.todos.map(({ id }) => id)
+    )
+
+    const selectTodoIdsLruWithResultEqualityCheck = lruMemoize(
+      (state: RootState) => state.todos.map(({ id }) => id),
+      { resultEqualityCheck: referenceEqualityCheck }
+    )
+
+    const memoizedFunctions = {
+      selectTodoIdsWeakMap,
+      selectTodoIdsWeakMapWithResultEqualityCheck,
+      selectTodoIdsLru,
+      selectTodoIdsLruWithResultEqualityCheck
+    }
+
+    setFunctionNames(memoizedFunctions)
+
+    const createOptions = <
+      Func extends AnyFunction & { resultsCount: () => number }
+    >(
+      memoizedFunction: Func
+    ) => {
+      const options: Options = {
+        setup: (task, mode) => {
+          if (mode === 'warmup') return
+
+          task.opts = {
+            beforeEach: () => {
+              store.dispatch(toggleCompleted(1))
+            },
+
+            afterAll: () => {
+              console.log(
+                memoizedFunction.name,
+                memoizedFunction.resultsCount()
+              )
+            }
+          }
+        }
+      }
+      return { ...commonOptions, ...options }
+    }
+
+    Object.values(memoizedFunctions).forEach(memoizedFunction => {
+      bench(
+        memoizedFunction,
+        () => {
+          runSelector(memoizedFunction)
+        },
+        createOptions(memoizedFunction)
+      )
+    })
+  })
+})

--- a/test/computationComparisons.spec.tsx
+++ b/test/computationComparisons.spec.tsx
@@ -304,18 +304,18 @@ describe('resultEqualityCheck in weakMapMemoize', () => {
     expect(memoized.resultsCount()).toBe(5)
 
     expect(memoizedShallow(state)).toBe(memoizedShallow(state))
-    expect(memoizedShallow.resultsCount()).toBe(0)
+    expect(memoizedShallow.resultsCount()).toBe(1)
     expect(memoizedShallow({ ...state })).toBe(memoizedShallow(state))
-    expect(memoizedShallow.resultsCount()).toBe(0)
+    expect(memoizedShallow.resultsCount()).toBe(1)
     expect(memoizedShallow({ ...state })).toBe(memoizedShallow(state))
     // We spread the state to force the function to re-run but the
     // result maintains the same reference because of `resultEqualityCheck`.
     const first = memoizedShallow({ ...state })
-    expect(memoizedShallow.resultsCount()).toBe(0)
+    expect(memoizedShallow.resultsCount()).toBe(1)
     memoizedShallow({ ...state })
-    expect(memoizedShallow.resultsCount()).toBe(0)
+    expect(memoizedShallow.resultsCount()).toBe(1)
     const second = memoizedShallow({ ...state })
-    expect(memoizedShallow.resultsCount()).toBe(0)
+    expect(memoizedShallow.resultsCount()).toBe(1)
     expect(first).toBe(second)
   })
 })

--- a/test/lruMemoize.test.ts
+++ b/test/lruMemoize.test.ts
@@ -1,9 +1,15 @@
 // TODO: Add test for React Redux connect function
 
-import { createSelectorCreator, lruMemoize } from 'reselect'
-import { vi } from 'vitest'
+import { shallowEqual } from 'react-redux'
+import {
+  createSelectorCreator,
+  lruMemoize,
+  referenceEqualityCheck
+} from 'reselect'
+import type { RootState } from './testUtils'
+import { localTest, toggleCompleted } from './testUtils'
 
-const createSelector = createSelectorCreator({
+const createSelectorLru = createSelectorCreator({
   memoize: lruMemoize,
   argsMemoize: lruMemoize
 })
@@ -268,7 +274,7 @@ describe(lruMemoize, () => {
 
     const fooChangeSpy = vi.fn()
 
-    const fooChangeHandler = createSelector(
+    const fooChangeHandler = createSelectorLru(
       (state: any) => state.foo,
       fooChangeSpy
     )
@@ -284,7 +290,7 @@ describe(lruMemoize, () => {
     const state2 = { a: 1 }
     let count = 0
 
-    const selector = createSelector([(state: any) => state.a], () => {
+    const selector = createSelectorLru([(state: any) => state.a], () => {
       count++
       return undefined
     })
@@ -361,7 +367,7 @@ describe(lruMemoize, () => {
     funcCalls = 0
 
     // Test out maxSize of 3 + exposure via createSelector
-    const selector = createSelector(
+    const selector = createSelectorLru(
       (state: string) => state,
       state => {
         funcCalls++
@@ -414,4 +420,135 @@ describe(lruMemoize, () => {
     // @ts-expect-error
     expect(selector.resultFunc.clearCache).toBeUndefined()
   })
+})
+
+describe('lruMemoize integration with resultEqualityCheck', () => {
+  const createAppSelector = createSelectorLru.withTypes<RootState>()
+
+  const resultEqualityCheck = vi
+    .fn(shallowEqual)
+    .mockName('resultEqualityCheck')
+
+  afterEach(() => {
+    resultEqualityCheck.mockClear()
+  })
+
+  localTest(
+    'resultEqualityCheck works when set to shallowEqual',
+    ({ store }) => {
+      const selectTodoIds = lruMemoize(
+        (state: RootState) => state.todos.map(({ id }) => id),
+        { resultEqualityCheck }
+      )
+
+      const firstResult = selectTodoIds(store.getState())
+
+      store.dispatch(toggleCompleted(0))
+
+      const secondResult = selectTodoIds(store.getState())
+
+      expect(firstResult).toBe(secondResult)
+
+      expect(selectTodoIds.resultsCount()).toBe(1)
+    }
+  )
+
+  localTest(
+    'resultEqualityCheck should not be called on the first output selector call',
+    ({ store }) => {
+      const selectTodoIds = createAppSelector(
+        [state => state.todos],
+        todos => todos.map(({ id }) => id),
+        {
+          memoizeOptions: { resultEqualityCheck },
+          devModeChecks: { inputStabilityCheck: 'once' }
+        }
+      )
+
+      expect(selectTodoIds(store.getState())).to.be.an('array').that.is.not
+        .empty
+
+      expect(resultEqualityCheck).not.toHaveBeenCalled()
+
+      store.dispatch(toggleCompleted(0))
+
+      expect(selectTodoIds.lastResult()).toBe(selectTodoIds(store.getState()))
+
+      expect(resultEqualityCheck).toHaveBeenCalledOnce()
+
+      expect(selectTodoIds.memoizedResultFunc.resultsCount()).toBe(1)
+
+      expect(selectTodoIds.recomputations()).toBe(2)
+
+      expect(selectTodoIds.resultsCount()).toBe(2)
+
+      expect(selectTodoIds.dependencyRecomputations()).toBe(2)
+
+      store.dispatch(toggleCompleted(0))
+
+      expect(selectTodoIds.lastResult()).toBe(selectTodoIds(store.getState()))
+
+      expect(resultEqualityCheck).toHaveBeenCalledTimes(2)
+
+      expect(selectTodoIds.memoizedResultFunc.resultsCount()).toBe(1)
+
+      expect(selectTodoIds.recomputations()).toBe(3)
+
+      expect(selectTodoIds.resultsCount()).toBe(3)
+
+      expect(selectTodoIds.dependencyRecomputations()).toBe(3)
+    }
+  )
+
+  localTest(
+    'lruMemoize with resultEqualityCheck set to referenceEqualityCheck works the same as lruMemoize without resultEqualityCheck',
+    ({ store }) => {
+      const resultEqualityCheck = vi
+        .fn(referenceEqualityCheck)
+        .mockName('resultEqualityCheck')
+
+      const selectTodoIdsWithResultEqualityCheck = lruMemoize(
+        (state: RootState) => state.todos.map(({ id }) => id),
+        { resultEqualityCheck }
+      )
+
+      const firstResultWithResultEqualityCheck =
+        selectTodoIdsWithResultEqualityCheck(store.getState())
+
+      expect(resultEqualityCheck).not.toHaveBeenCalled()
+
+      store.dispatch(toggleCompleted(0))
+
+      const secondResultWithResultEqualityCheck =
+        selectTodoIdsWithResultEqualityCheck(store.getState())
+
+      expect(firstResultWithResultEqualityCheck).not.toBe(
+        secondResultWithResultEqualityCheck
+      )
+
+      expect(firstResultWithResultEqualityCheck).toStrictEqual(
+        secondResultWithResultEqualityCheck
+      )
+
+      expect(selectTodoIdsWithResultEqualityCheck.resultsCount()).toBe(2)
+
+      const selectTodoIds = lruMemoize((state: RootState) =>
+        state.todos.map(({ id }) => id)
+      )
+
+      const firstResult = selectTodoIds(store.getState())
+
+      store.dispatch(toggleCompleted(0))
+
+      const secondResult = selectTodoIds(store.getState())
+
+      expect(firstResult).not.toBe(secondResult)
+
+      expect(firstResult).toStrictEqual(secondResult)
+
+      expect(selectTodoIds.resultsCount()).toBe(2)
+
+      resultEqualityCheck.mockClear()
+    }
+  )
 })

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,13 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { combineReducers, configureStore, createSlice } from '@reduxjs/toolkit'
 import { test } from 'vitest'
-import type { lruMemoize } from '../src/lruMemoize'
-import type {
-  AnyFunction,
-  OutputSelector,
-  SelectorArray,
-  Simplify
-} from '../src/types'
+import type { AnyFunction, OutputSelector, Simplify } from '../src/types'
 
 export interface Todo {
   id: number
@@ -437,22 +431,17 @@ export const logRecomputations = <S extends OutputSelector>(selector: S) => {
   )
 }
 
-export const logSelectorRecomputations = <
-  S extends OutputSelector<SelectorArray, unknown, typeof lruMemoize, any>
->(
+export const logSelectorRecomputations = <S extends OutputSelector>(
   selector: S
 ) => {
-  console.log(
-    `\x1B[32m\x1B[1m${selector.name}\x1B[0m result function recalculated:`,
-    {
-      resultFunc: selector.recomputations(),
-      inputSelectors: selector.dependencyRecomputations(),
-      newResults:
-        typeof selector.memoizedResultFunc.resultsCount === 'function'
-          ? selector.memoizedResultFunc.resultsCount()
-          : undefined
-    }
-  )
+  console.log(`\x1B[32m\x1B[1m${selector.name}\x1B[0m:`, {
+    resultFunc: selector.recomputations(),
+    inputSelectors: selector.dependencyRecomputations(),
+    newResults:
+      typeof selector.memoizedResultFunc.resultsCount === 'function'
+        ? selector.memoizedResultFunc.resultsCount()
+        : undefined
+  })
   // console.log(
   //   `\x1B[32m\x1B[1m${selector.name}\x1B[0m result function recalculated:`,
   //   `\x1B[33m${selector.recomputations().toLocaleString('en-US')}\x1B[0m`,


### PR DESCRIPTION
## Overview
Previously using [`weakMapMemoize`](https://reselect.js.org/api/weakMapMemoize)with `resultEqualityCheck` would cause the `resultEqualityCheck` to be called with empty objects as arguments due to how [`inputStabilityCheck`](https://reselect.js.org/api/development-only-stability-checks#inputstabilitycheck) works. Here's a summary of the changes:

**This PR**:

  - [X] Fixes `resultEqualityCheck` in [`weakMapMemoize`](https://reselect.js.org/api/weakMapMemoize) so that when input selectors are stable, `resultEqualityCheck` does not get called on the first run of the output selector.
  - [X] Adds runtime unit tests to verify that:
    - `resultEqualityCheck` works correctly when set to `shallowEqual`.
    - `resultEqualityCheck` is not called on the first output selector call.
    - [`weakMapMemoize`](https://reselect.js.org/api/weakMapMemoize)/[`lruMemoize`](https://reselect.js.org/api/lruMemoize) with `resultEqualityCheck` set to `referenceEqualityCheck` works the same as [`weakMapMemoize`](https://reselect.js.org/api/weakMapMemoize)/[`lruMemoize`](https://reselect.js.org/api/lruMemoize) without `resultEqualityCheck`.
  - [X] Adds benchmarks to measure the `resultEqualityCheck` performance impact.
  - [X] Adds unit tests to test the dynamics between [`inputStabilityCheck`](https://reselect.js.org/api/development-only-stability-checks#inputstabilitycheck) and `resultEqualityCheck`.
  - [X] Fixes a specific bug within [`weakMapMemoize`](https://reselect.js.org/api/weakMapMemoize) where setting `resultEqualityCheck` to `referenceEqualityCheck` would prevent `memoizedResultFunc.resultsCount()` from incrementing upon result recalculation.
  - [X] Fixes a performance issue in [`weakMapMemoize`](https://reselect.js.org/api/weakMapMemoize) when comparing two memoized functions, one with `resultEqualityCheck` set to `referenceEqualityCheck` and the other without `resultEqualityCheck`. Previously, there was a noticeable discrepancy between the two, which has now been corrected to achieve the desired effect.