### PR TITLE
Fix: use unique value for NOT_FOUND

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,9 +9,7 @@ import type {
   DevModeChecksExecutionInfo
 } from './types'
 
-class NotFound {}
-
-export const NOT_FOUND = new NotFound()
+export const NOT_FOUND = Symbol('NOT_FOUND')
 export type NOT_FOUND_TYPE = typeof NOT_FOUND
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import type {
   DevModeChecksExecutionInfo
 } from './types'
 
-export const NOT_FOUND = Symbol('NOT_FOUND')
+export const NOT_FOUND = /* @__PURE__ */ Symbol('NOT_FOUND')
 export type NOT_FOUND_TYPE = typeof NOT_FOUND
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,9 @@ import type {
   DevModeChecksExecutionInfo
 } from './types'
 
-export const NOT_FOUND = 'NOT_FOUND'
+class NotFound {}
+
+export const NOT_FOUND = new NotFound()
 export type NOT_FOUND_TYPE = typeof NOT_FOUND
 
 /**


### PR DESCRIPTION
I'm not sure what's the reasoning for using a string constant for the not-found value, but an object feels both safer (real uniqueness, the string `'NOT_FOUND'` could make the logic fail) and more performant (no `strcmp()` if both values are strings) which is handy when the selectors are called very often.

I've used a private class instance for the empty value because you seem to use the value type `NOT_FOUND_TYPE`, otherwise I would have gone with a `Symbol('not-found')` or an empty object, but any of these would be fine I think.