### PR TITLE
Replace usage of deprecated `JSX` global namespace with `React.JSX`

### DIFF
--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -1,6 +1,6 @@
 import Heading from '@theme/Heading'
 import clsx from 'clsx'
-import type { FC } from 'react'
+import type { FC, JSX } from 'react'
 import { memo } from 'react'
 import styles from './styles.module.css'
 


### PR DESCRIPTION
## This PR:

  - [X] Runs `npx types-react-codemod scoped-jsx .` to replace usage of the deprecated `JSX` global namespace with `React.JSX` in preparation for React 19.
  
### Relevant Links:
  
  - [The `JSX` namespace in TypeScript](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript)
  - [`scoped-jsx` codemod](https://github.com/eps1lon/types-react-codemod/?tab=readme-ov-file#scoped-jsx)