### PR TITLE
fix: don't pass `resultEqualityCheck` to `inputStabilityCheck` probe

### DIFF
--- a/src/devModeChecks/inputStabilityCheck.ts
+++ b/src/devModeChecks/inputStabilityCheck.ts
@@ -30,7 +30,29 @@ export const runInputStabilityCheck = (
   const { memoize, memoizeOptions } = options
   const { inputSelectorResults, inputSelectorResultsCopy } =
     inputSelectorResultsObject
-  const createAnEmptyObject = memoize(() => ({}), ...memoizeOptions)
+  // The probe function below intentionally returns a new object reference on
+  // every call so we can detect whether `memoize` considers the two sets of
+  // input selector results to be equal. A user-provided `resultEqualityCheck`
+  // is irrelevant to that comparison (it compares *results*, not arguments) and
+  // must not run here, otherwise it would be invoked with these empty probe
+  // objects rather than the actual selector results. See #693.
+  const memoizeOptionsWithoutResultEqualityCheck = (
+    memoizeOptions as unknown[]
+  ).map(option => {
+    if (
+      option != null &&
+      typeof option === 'object' &&
+      'resultEqualityCheck' in option
+    ) {
+      const { resultEqualityCheck, ...rest } = option as Record<string, unknown>
+      return rest
+    }
+    return option
+  })
+  const createAnEmptyObject = memoize(
+    () => ({}),
+    ...memoizeOptionsWithoutResultEqualityCheck
+  )
   // if the memoize method thinks the parameters are equal, these *should* be the same reference
   const areInputSelectorResultsEqual =
     createAnEmptyObject.apply(null, inputSelectorResults) ===

--- a/test/inputStabilityCheck.spec.ts
+++ b/test/inputStabilityCheck.spec.ts
@@ -272,4 +272,72 @@ describe('the effects of inputStabilityCheck with resultEqualityCheck', () => {
       expect(resultEqualityCheck).not.toHaveBeenCalled()
     }
   )
+
+  localTest(
+    'resultEqualityCheck should not be called with empty objects when inputStabilityCheck is set to once and input selectors are unstable',
+    ({ store }) => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const selectTodoIds = createAppSelector(
+        [state => [...state.todos]],
+        todos => todos.map(({ id }) => id),
+        {
+          memoizeOptions: { resultEqualityCheck },
+          devModeChecks: { inputStabilityCheck: 'once' }
+        }
+      )
+
+      // The first call runs `inputStabilityCheck`, which internally memoizes a
+      // probe function returning empty objects. Because the input selector is
+      // unstable, the probe runs twice with differing arguments. The user's
+      // `resultEqualityCheck` must not be invoked with those empty probe objects.
+      const firstResult = selectTodoIds(store.getState())
+
+      for (const call of resultEqualityCheck.mock.calls) {
+        expect(call[0]).toBeInstanceOf(Array)
+        expect(call[1]).toBeInstanceOf(Array)
+      }
+
+      const secondResult = selectTodoIds(store.getState())
+
+      for (const call of resultEqualityCheck.mock.calls) {
+        expect(call[0]).toBeInstanceOf(Array)
+        expect(call[1]).toBeInstanceOf(Array)
+      }
+
+      // Sanity check: the unstable input still triggers the stability warning.
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
+
+      expect(firstResult).toBe(secondResult)
+
+      consoleSpy.mockRestore()
+    }
+  )
+
+  localTest(
+    'resultEqualityCheck should not be called with empty objects when inputStabilityCheck is set to always and input selectors are unstable',
+    ({ store }) => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const selectTodoIds = createAppSelector(
+        [state => [...state.todos]],
+        todos => todos.map(({ id }) => id),
+        {
+          memoizeOptions: { resultEqualityCheck },
+          devModeChecks: { inputStabilityCheck: 'always' }
+        }
+      )
+
+      selectTodoIds(store.getState())
+      selectTodoIds(store.getState())
+      selectTodoIds(store.getState())
+
+      for (const call of resultEqualityCheck.mock.calls) {
+        expect(call[0]).toBeInstanceOf(Array)
+        expect(call[1]).toBeInstanceOf(Array)
+      }
+
+      consoleSpy.mockRestore()
+    }
+  )
 })


### PR DESCRIPTION
## Overview

Fixes the remaining half of #693: when input selectors return **unstable** references, `inputStabilityCheck` invokes the user's `resultEqualityCheck` with empty probe objects (`{}`) instead of the actual selector results, breaking any `resultEqualityCheck` that inspects the result's shape.

## Root cause

[`runInputStabilityCheck`](https://github.com/reduxjs/reselect/blob/master/src/devModeChecks/inputStabilityCheck.ts) memoizes an internal probe function that returns a fresh empty object on every call:

```ts
const createAnEmptyObject = memoize(() => ({}), ...memoizeOptions)
```

The probe is used to detect whether the configured memoizer treats the two sets of input selector results as equal. The problem is that `memoizeOptions` includes the user's `resultEqualityCheck`. When the input selectors are unstable — the exact scenario this check exists to detect — the probe is called twice with arguments the memoizer considers different, so the memoizer runs `resultEqualityCheck` on the two `{}` probe results.

As [reported by @keegan-lillo](https://github.com/reduxjs/reselect/issues/693) and confirmed by @EskiMojo14 and @braeden in that thread, a real-world `resultEqualityCheck` (e.g. one that compares a `Set` or reads properties off the result) then throws a development-only runtime error.

#699 fixed only the **stable**-input path (so `resultEqualityCheck` is not called on the first run when inputs are stable). It did not address the unstable-input path, which is why #693 is still open.

### Reproduction (on `master`)

```ts
const resultEqualityCheck = (a, b) => { console.log({ a, b }); return a === b }
const selector = createSelector(
  // unstable input selector — returns a new object reference each call
  [(state) => ({ v: state.value })],
  (obj) => `result:${obj.v}`,
  { memoize: weakMapMemoize, memoizeOptions: { resultEqualityCheck } }
)
selector({ value: 'a' })
// logs: { a: {}, b: {} }  <-- resultEqualityCheck called with empty probe objects
```

## The fix

Strip `resultEqualityCheck` from the options used to build the probe memoizer. `resultEqualityCheck` compares *results*, not arguments, so it is irrelevant to what the probe measures, and it should never run against the probe objects.

The first options arg can be either an options object or (for `lruMemoize`'s function-style API) an `equalityCheck` function, so the property is only removed when the option is an object that actually contains `resultEqualityCheck`. All other options (`equalityCheck`, `maxSize`, …) are preserved, so the memoizer's notion of argument equality is unchanged and the stability warning still fires correctly.

## Tests

Adds regression tests for the previously-uncovered combinations (`inputStabilityCheck` set to `once` and `always` with **unstable** inputs). They fail on `master` (`resultEqualityCheck` receives `{}`) and pass with this change. Existing tests — including the stable-input and `never` cases — continue to pass, and the stability warning is still asserted to fire.

Closes #693