### PR TITLE
feat: add `maxSize` option to `weakMapMemoize` to bound cache growth (#635)

### DIFF
--- a/.github/workflows/build-and-test-types.yml
+++ b/.github/workflows/build-and-test-types.yml
@@ -125,8 +125,10 @@ jobs:
           path: .
 
       # Note: We currently expect "FalseCJS" failures for Node16 + `moduleResolution: "node16",
+      # Pinned to 0.18.5+: 0.18.2 crashes ("Cannot read properties of undefined (reading 'filename')")
+      # because it kept only the last (empty) gunzip chunk; fixed by concatenating all chunks.
       - name: Run are-the-types-wrong
-        run: npx @arethetypeswrong/cli@0.18.3 ./package.tgz --format table --ignore-rules false-cjs
+        run: npx @arethetypeswrong/cli@0.18.5 ./package.tgz --format table --ignore-rules false-cjs
 
   test-published-artifact:
     name: Test Published Artifact ${{ matrix.example }}

--- a/src/weakMapMemoize.ts
+++ b/src/weakMapMemoize.ts
@@ -31,34 +31,13 @@ const Ref = /* @__PURE__ */ getWeakRef()
 const UNTERMINATED = 0
 const TERMINATED = 1
 
-interface UnterminatedCacheNode<T> {
-  /**
-   * Status, represents whether the cached computation returned a value or threw an error.
-   */
-  s: 0
-  /**
-   * Value, either the cached result or an error, depending on status.
-   */
-  v: void
-  /**
-   * Object cache, a `WeakMap` where non-primitive arguments are stored.
-   */
-  o: null | WeakMap<Function | Object, CacheNode<T>>
-  /**
-   * Primitive cache, a regular Map where primitive arguments are stored.
-   */
-  p: null | Map<string | number | null | void | symbol | boolean, CacheNode<T>>
-}
-
-interface TerminatedCacheNode<T> {
-  /**
-   * Status, represents whether the cached computation returned a value or threw an error.
-   */
-  s: 1
-  /**
-   * Value, either the cached result or an error, depending on status.
-   */
-  v: T
+/**
+ * Fields shared by every cache node, regardless of termination status. The
+ * back-references (`parent`/`map`/`key`) and LRU links (`lru`/`mru`) are only
+ * used when a `maxSize` is configured, so that terminated nodes can be evicted
+ * and their now-empty ancestors pruned out of the strong primitive `Map`s.
+ */
+interface CacheNodeBase<T> {
   /**
    * Object cache, a `WeakMap` where non-primitive arguments are stored.
    */
@@ -67,6 +46,51 @@ interface TerminatedCacheNode<T> {
    * Primitive cache, a regular `Map` where primitive arguments are stored.
    */
   p: null | Map<string | number | null | void | symbol | boolean, CacheNode<T>>
+  /**
+   * The parent cache node, or `null` for the root node.
+   */
+  parent: CacheNode<T> | null
+  /**
+   * The `Map`/`WeakMap` in {@linkcode parent} that holds this node.
+   */
+  map:
+    | Map<any, CacheNode<T>>
+    | WeakMap<Function | Object, CacheNode<T>>
+    | null
+  /**
+   * The key under which this node is stored in {@linkcode map}.
+   */
+  key: any
+  /**
+   * Previous (less recently used) node in the LRU list, or `null`.
+   */
+  lru: CacheNode<T> | null
+  /**
+   * Next (more recently used) node in the LRU list, or `null`.
+   */
+  mru: CacheNode<T> | null
+}
+
+interface UnterminatedCacheNode<T> extends CacheNodeBase<T> {
+  /**
+   * Status, represents whether the cached computation returned a value or threw an error.
+   */
+  s: 0
+  /**
+   * Value, either the cached result or an error, depending on status.
+   */
+  v: void
+}
+
+interface TerminatedCacheNode<T> extends CacheNodeBase<T> {
+  /**
+   * Status, represents whether the cached computation returned a value or threw an error.
+   */
+  s: 1
+  /**
+   * Value, either the cached result or an error, depending on status.
+   */
+  v: T
 }
 
 type CacheNode<T> = TerminatedCacheNode<T> | UnterminatedCacheNode<T>
@@ -76,7 +100,12 @@ function createCacheNode<T>(): CacheNode<T> {
     s: UNTERMINATED,
     v: undefined,
     o: null,
-    p: null
+    p: null,
+    parent: null,
+    map: null,
+    key: undefined,
+    lru: null,
+    mru: null
   }
 }
 
@@ -102,6 +131,30 @@ export interface WeakMapMemoizeOptions<Result = any> {
    * @since 5.0.0
    */
   resultEqualityCheck?: EqualityFn<Result>
+
+  /**
+   * The maximum number of results to keep in the cache at once.
+   *
+   * By default `weakMapMemoize` has an effectively infinite cache size: results
+   * are kept alive for as long as the arguments used to compute them remain
+   * reachable. This is ideal when the arguments are objects that get garbage
+   * collected (such as the Redux state), but can behave like a memory leak when
+   * a long-lived object argument is combined with ever-changing primitive
+   * arguments — every result computed for every primitive combination is
+   * retained for the lifetime of that object.
+   *
+   * Providing a `maxSize` caps the number of cached results using a least-
+   * recently-used (LRU) policy. Once the limit is exceeded, the least recently
+   * used result is evicted and any now-empty `Map` branches holding primitive
+   * arguments are pruned, allowing those results to be garbage collected.
+   *
+   * Must be a positive integer. When omitted, the cache size is unbounded.
+   *
+   * @see {@link https://github.com/reduxjs/reselect/issues/635}
+   *
+   * @since 5.2.1
+   */
+  maxSize?: number
 }
 
 /**
@@ -196,7 +249,62 @@ export function weakMapMemoize<Func extends AnyFunction>(
   options: WeakMapMemoizeOptions<ReturnType<Func>> = {}
 ) {
   let fnNode = createCacheNode()
-  const { resultEqualityCheck } = options
+  const { resultEqualityCheck, maxSize } = options
+
+  const useLru = maxSize !== undefined
+  if (useLru && (!Number.isInteger(maxSize) || maxSize < 1)) {
+    throw new TypeError(
+      `the \`maxSize\` option for weakMapMemoize must be a positive integer, but received: ${maxSize}`
+    )
+  }
+
+  // Doubly linked LRU list of terminated cache nodes. `lruMost` is the most
+  // recently used node, `lruLeast` the least recently used (eviction target).
+  let lruMost: CacheNode<any> | null = null
+  let lruLeast: CacheNode<any> | null = null
+  let cacheSize = 0
+
+  const lruDetach = (node: CacheNode<any>) => {
+    const { lru, mru } = node
+    if (lru !== null) lru.mru = mru
+    else lruLeast = mru
+    if (mru !== null) mru.lru = lru
+    else lruMost = lru
+    node.lru = node.mru = null
+  }
+
+  const lruPromote = (node: CacheNode<any>) => {
+    if (node === lruMost) return
+    if (node.lru !== null || node.mru !== null || node === lruLeast) {
+      lruDetach(node)
+    }
+    node.lru = lruMost
+    node.mru = null
+    if (lruMost !== null) lruMost.mru = node
+    lruMost = node
+    if (lruLeast === null) lruLeast = node
+  }
+
+  /**
+   * Removes a terminated node from the cache tree and prunes any ancestors that
+   * are left holding nothing, so the strong primitive `Map`s can't grow forever.
+   */
+  const evict = (node: CacheNode<any>) => {
+    let current: CacheNode<any> | null = node
+    while (current !== null && current.map !== null) {
+      current.map.delete(current.key)
+      const parent: CacheNode<any> | null = current.parent
+      if (
+        parent === null ||
+        parent.s === TERMINATED || // still caches a value of its own
+        parent.o !== null || // still has object-keyed children (a `WeakMap`)
+        (parent.p !== null && parent.p.size > 0) // still has primitive children
+      ) {
+        break
+      }
+      current = parent
+    }
+  }
 
   let lastResult: WeakRef<object> | undefined
 
@@ -218,8 +326,14 @@ export function weakMapMemoize<Func extends AnyFunction>(
         }
         const objectNode = objectCache.get(arg)
         if (objectNode === undefined) {
+          const parentNode = cacheNode
           cacheNode = createCacheNode()
           objectCache.set(arg, cacheNode)
+          if (useLru) {
+            cacheNode.parent = parentNode
+            cacheNode.map = objectCache
+            cacheNode.key = arg
+          }
         } else {
           cacheNode = objectNode
         }
@@ -231,8 +345,14 @@ export function weakMapMemoize<Func extends AnyFunction>(
         }
         const primitiveNode = primitiveCache.get(arg)
         if (primitiveNode === undefined) {
+          const parentNode = cacheNode
           cacheNode = createCacheNode()
           primitiveCache.set(arg, cacheNode)
+          if (useLru) {
+            cacheNode.parent = parentNode
+            cacheNode.map = primitiveCache
+            cacheNode.key = arg
+          }
         } else {
           cacheNode = primitiveNode
         }
@@ -245,6 +365,8 @@ export function weakMapMemoize<Func extends AnyFunction>(
 
     if (cacheNode.s === TERMINATED) {
       result = cacheNode.v
+      // Mark this result as most recently used so it survives eviction longest.
+      if (useLru) lruPromote(cacheNode)
     } else {
       // Allow errors to propagate
       result = func.apply(null, arguments as unknown as any[])
@@ -271,14 +393,32 @@ export function weakMapMemoize<Func extends AnyFunction>(
       }
     }
 
+    const wasUnterminated = cacheNode.s === UNTERMINATED
+
     terminatedNode.s = TERMINATED
 
     terminatedNode.v = result
+
+    if (useLru && wasUnterminated) {
+      // A brand new result was cached: track it as most recently used and
+      // evict the least recently used result once we're over `maxSize`.
+      lruPromote(terminatedNode)
+      cacheSize++
+      if (cacheSize > (maxSize as number)) {
+        const toEvict = lruLeast!
+        lruDetach(toEvict)
+        cacheSize--
+        evict(toEvict)
+      }
+    }
+
     return result
   }
 
   memoized.clearCache = () => {
     fnNode = createCacheNode()
+    lruMost = lruLeast = null
+    cacheSize = 0
     memoized.resetResultsCount()
   }
 

--- a/test/customMatchers.d.ts
+++ b/test/customMatchers.d.ts
@@ -2,6 +2,7 @@ import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
 
 interface CustomMatchers<R = unknown> {
   toBeMemoizedSelector(): R
+  toBeGarbageCollected(): Promise<R>
 }
 
 declare module 'vitest' {

--- a/test/setup.vitest.ts
+++ b/test/setup.vitest.ts
@@ -1,5 +1,23 @@
 import { isMemoizedSelector } from './testUtils'
 
+/**
+ * Repeatedly triggers garbage collection and yields to the event loop so that
+ * finalizers/`WeakRef`s have a chance to observe collection. Requires the test
+ * process to be started with `node --expose-gc` (see the `test` npm script).
+ */
+const waitForGarbageCollection = async () => {
+  if (typeof globalThis.gc !== 'function') {
+    throw new Error(
+      'These tests require garbage collection access. Run vitest via `node --expose-gc`.'
+    )
+  }
+  for (let i = 0; i < 10; i++) {
+    globalThis.gc()
+    // Let the microtask/macrotask queue flush between GC passes.
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
 expect.extend({
   toBeMemoizedSelector(received) {
     const { isNot } = this
@@ -7,6 +25,24 @@ expect.extend({
     return {
       pass: isMemoizedSelector(received),
       message: () => `${received} is${isNot ? '' : ' not'} a memoized selector`
+    }
+  },
+
+  /**
+   * Asserts that the value held by a `WeakRef` has (or has not, when negated)
+   * been garbage collected. Modeled after Apollo Client's matcher of the same
+   * name.
+   */
+  async toBeGarbageCollected(received: WeakRef<any>) {
+    const { isNot } = this
+    await waitForGarbageCollection()
+    const pass = received.deref() === undefined
+    return {
+      pass,
+      message: () =>
+        `expected referenced value to${
+          isNot ? ' not' : ''
+        } have been garbage collected`
     }
   }
 })

--- a/test/weakMapMemoize.allocations.spec.ts
+++ b/test/weakMapMemoize.allocations.spec.ts
@@ -1,0 +1,210 @@
+import {
+  createSelector,
+  lruMemoize,
+  setGlobalDevModeChecks,
+  weakMapMemoize
+} from 'reselect'
+
+/**
+ * Companion to `weakMapMemoize.memory.spec.ts` for
+ * https://github.com/reduxjs/reselect/issues/635
+ *
+ * Where the benchmarks report timings, which vary from machine to machine,
+ * these tests pin down the number of cache nodes a call allocates. That number
+ * follows from the shape of the cache tree, so it is the same everywhere.
+ *
+ * `weakMapMemoize` stores each argument at its own level of the tree, so a
+ * cache miss allocates one node per argument, and `createSelector` builds two
+ * of these trees: one for the arguments the output selector was called with
+ * (`argsMemoize`) and one for the values the input selectors extracted
+ * (`memoize`).
+ */
+
+interface AllocationCounts {
+  /** `Map` instances constructed, i.e. levels of the tree holding primitives. */
+  maps: number
+  /** `WeakMap` instances constructed, i.e. levels holding objects. */
+  weakMaps: number
+  /**
+   * Entries stored across all of those maps. Every one of them is a freshly
+   * created cache node, so this doubles as the number of nodes allocated.
+   */
+  cacheNodes: number
+}
+
+/**
+ * Counts the maps and cache nodes allocated while `run` executes, by swapping
+ * in counting subclasses of `Map` and `WeakMap`. `weakMapMemoize` constructs
+ * both lazily through the global bindings, so this observes it without
+ * changing its behavior.
+ */
+const measureAllocations = (run: () => void) => {
+  const counts: AllocationCounts = { maps: 0, weakMaps: 0, cacheNodes: 0 }
+
+  const OriginalMap = globalThis.Map
+  const OriginalWeakMap = globalThis.WeakMap
+
+  class CountingMap<K, V> extends OriginalMap<K, V> {
+    constructor(entries?: readonly (readonly [K, V])[] | null) {
+      super(entries)
+      counts.maps++
+    }
+    set(key: K, value: V) {
+      counts.cacheNodes++
+      return super.set(key, value)
+    }
+  }
+
+  class CountingWeakMap<K extends WeakKey, V> extends OriginalWeakMap<K, V> {
+    constructor(entries?: readonly (readonly [K, V])[] | null) {
+      super(entries)
+      counts.weakMaps++
+    }
+    set(key: K, value: V) {
+      counts.cacheNodes++
+      return super.set(key, value)
+    }
+  }
+
+  globalThis.Map = CountingMap as unknown as MapConstructor
+  globalThis.WeakMap = CountingWeakMap as unknown as WeakMapConstructor
+
+  try {
+    run()
+  } finally {
+    globalThis.Map = OriginalMap
+    globalThis.WeakMap = OriginalWeakMap
+  }
+
+  return counts
+}
+
+interface TestState {
+  todos: { id: number }[]
+}
+
+const state: TestState = { todos: [{ id: 0 }, { id: 1 }] }
+
+const selectTodos = (state: TestState) => state.todos
+const selectId = (state: TestState, id: number) => id
+
+const createParametricSelector = () =>
+  createSelector([selectTodos, selectId], (todos, id) => todos.length + id)
+
+const createLruParametricSelector = () =>
+  createSelector([selectTodos, selectId], (todos, id) => todos.length + id, {
+    memoize: lruMemoize,
+    argsMemoize: lruMemoize
+  })
+
+describe('what a weakMapMemoize cache miss allocates', () => {
+  const CALLS = 1_000
+
+  // The development-only checks call the input selectors and the result
+  // function some extra times on a selector's first call, which shows up as a
+  // couple of extra nodes. Turning them off keeps these counts exact.
+  beforeAll(() => {
+    setGlobalDevModeChecks({
+      inputStabilityCheck: 'never',
+      identityFunctionCheck: 'never'
+    })
+  })
+
+  afterAll(() => {
+    setGlobalDevModeChecks({
+      inputStabilityCheck: 'once',
+      identityFunctionCheck: 'once'
+    })
+  })
+
+  const nodesForCalls = (calls: number) =>
+    measureAllocations(() => {
+      const selector = createParametricSelector()
+      for (let i = 0; i < calls; i++) {
+        selector(state, i)
+      }
+    })
+
+  test('allocates two cache nodes per unique argument', () => {
+    const counts = nodesForCalls(CALLS)
+
+    // One `WeakMap` per tree, holding the single object argument (the state
+    // for `argsMemoize`, the todos array for `memoize`), and one `Map` per
+    // tree, holding the id.
+    expect(counts.weakMaps).toBe(2)
+    expect(counts.maps).toBe(2)
+
+    // Two nodes for every distinct id - one in each tree - plus the two nodes
+    // the object arguments are stored under.
+    expect(counts.cacheNodes).toBe(CALLS * 2 + 2)
+  })
+
+  test('the number of nodes grows linearly with the number of distinct arguments', () => {
+    const single = nodesForCalls(CALLS).cacheNodes
+    const double = nodesForCalls(CALLS * 2).cacheNodes
+    const quadruple = nodesForCalls(CALLS * 4).cacheNodes
+
+    // Two more nodes for every additional distinct argument. Without a
+    // `maxSize` nothing is evicted along the way.
+    expect(double - single).toBe(CALLS * 2)
+    expect(quadruple - double).toBe(CALLS * 2 * 2)
+  })
+
+  test('a cache hit allocates nothing', () => {
+    const selector = createParametricSelector()
+    selector(state, 0)
+
+    const counts = measureAllocations(() => {
+      for (let i = 0; i < CALLS; i++) {
+        selector(state, 0)
+      }
+    })
+
+    expect(counts).toEqual({ maps: 0, weakMaps: 0, cacheNodes: 0 })
+  })
+
+  test('lruMemoize allocates no maps, since it caches in an array', () => {
+    const counts = measureAllocations(() => {
+      const selector = createLruParametricSelector()
+      for (let i = 0; i < CALLS; i++) {
+        selector(state, i)
+      }
+    })
+
+    expect(counts).toEqual({ maps: 0, weakMaps: 0, cacheNodes: 0 })
+  })
+
+  test('every argument adds another level to the tree', () => {
+    const counts = measureAllocations(() => {
+      const memoized = weakMapMemoize(
+        (array: number[], from: number, to: number) => array.slice(from, to)
+      )
+      const array = [1, 2, 3, 4, 5]
+      memoized(array, 0, 1)
+    })
+
+    // One `WeakMap` for the array, one `Map` per primitive argument.
+    expect(counts.weakMaps).toBe(1)
+    expect(counts.maps).toBe(2)
+    expect(counts.cacheNodes).toBe(3)
+  })
+
+  test('maxSize caps the nodes that stay in the tree', () => {
+    const MAX_SIZE = 10
+
+    const counts = measureAllocations(() => {
+      const memoized = weakMapMemoize(
+        (array: number[], from: number) => array.slice(from),
+        { maxSize: MAX_SIZE }
+      )
+      const array = [1, 2, 3, 4, 5]
+      for (let i = 0; i < CALLS; i++) {
+        memoized(array, i)
+      }
+    })
+
+    // Nodes are still allocated per miss - eviction bounds what is retained,
+    // not what is created.
+    expect(counts.cacheNodes).toBe(CALLS + 1)
+  })
+})

--- a/test/weakMapMemoize.memory.spec.ts
+++ b/test/weakMapMemoize.memory.spec.ts
@@ -1,0 +1,136 @@
+import { weakMapMemoize } from 'reselect'
+
+/**
+ * Confirmation tests for https://github.com/reduxjs/reselect/issues/635
+ *
+ * `weakMapMemoize` stores primitive arguments in strong `Map`s that live inside
+ * the cache tree. When the *first* argument is a long-lived object (e.g. the
+ * Redux state, or a stable derived value) but later primitive arguments keep
+ * changing, every result that was ever computed is retained for as long as that
+ * first object stays reachable — an unbounded cache that behaves like a leak.
+ *
+ * These tests require `node --expose-gc` (already used by the `test` script).
+ */
+
+const makeSliceSelector = (options?: Parameters<typeof weakMapMemoize>[1]) =>
+  weakMapMemoize(
+    (array: number[], from: number, to: number) => array.slice(from, to),
+    options
+  )
+
+describe('weakMapMemoize unbounded cache (issue #635)', () => {
+  test('retains every result forever while the object arg stays alive (leak)', () => {
+    const selector = makeSliceSelector()
+
+    // Long-lived object argument (imagine this is the Redux state).
+    const state = Array.from({ length: 10_000 }, (_, i) => i)
+
+    const initialResult = selector(state, 2000, 2500)
+
+    // Simulate an endlessly scrolling list: the primitive args keep changing.
+    for (let i = 0; i < 10_000; i++) {
+      selector(state, i, i + 100)
+    }
+
+    // The very first result is STILL memoized after 10k different calls.
+    // This is the leak: nothing is ever evicted.
+    expect(selector(state, 2000, 2500)).toBe(initialResult)
+  })
+
+  test('old results are not garbage collected while the object arg is alive (leak)', async () => {
+    const selector = makeSliceSelector()
+    const state = Array.from({ length: 10_000 }, (_, i) => i)
+
+    const initialResult = new WeakRef(selector(state, 2000, 2500))
+
+    for (let i = 0; i < 10_000; i++) {
+      selector(state, i, i + 100)
+    }
+
+    // Because the cache holds a strong reference to every computed slice,
+    // the initial result cannot be collected even though nothing else
+    // references it. Both `state` (the WeakMap key) and `selector` (which owns
+    // the cache tree) must stay reachable, otherwise the whole cache — and thus
+    // the result — would be collected for unrelated reasons.
+    await expect(initialResult).not.toBeGarbageCollected()
+    expect(state.length).toBe(10_000)
+    expect(selector(state, 2000, 2500)).toBe(initialResult.deref())
+  })
+})
+
+describe('weakMapMemoize maxSize (fix for issue #635)', () => {
+  test('rejects a non-positive-integer maxSize', () => {
+    expect(() => makeSliceSelector({ maxSize: 0 })).toThrow(/positive integer/)
+    expect(() => makeSliceSelector({ maxSize: -1 })).toThrow(/positive integer/)
+    expect(() => makeSliceSelector({ maxSize: 1.5 })).toThrow(/positive integer/)
+  })
+
+  test('still caches within the configured size', () => {
+    const selector = weakMapMemoize(
+      (array: number[], from: number, to: number) => array.slice(from, to),
+      { maxSize: 3 }
+    )
+    const state = [1, 2, 3, 4, 5]
+
+    const a = selector(state, 0, 2)
+    const b = selector(state, 1, 3)
+
+    // Repeated calls within maxSize are still memoized.
+    expect(selector(state, 0, 2)).toBe(a)
+    expect(selector(state, 1, 3)).toBe(b)
+  })
+
+  test('evicts the least recently used result once maxSize is exceeded', () => {
+    const selector = weakMapMemoize(
+      (array: number[], from: number, to: number) => array.slice(from, to),
+      { maxSize: 2 }
+    )
+    const state = [1, 2, 3, 4, 5]
+
+    const first = selector(state, 0, 1) // cache: [first]
+    selector(state, 1, 2) // cache: [first, second]
+    selector(state, 2, 3) // exceeds maxSize -> evicts `first`
+
+    // `first` was evicted, so it is recomputed as a fresh reference.
+    expect(selector(state, 0, 1)).not.toBe(first)
+    expect(selector(state, 0, 1)).toEqual([1])
+  })
+
+  test('a most-recently-used result is kept while a stale one is evicted', () => {
+    const selector = weakMapMemoize(
+      (array: number[], from: number, to: number) => array.slice(from, to),
+      { maxSize: 2 }
+    )
+    const state = [1, 2, 3, 4, 5]
+
+    const keep = selector(state, 0, 2)
+    selector(state, 1, 3)
+    // Touch `keep` so it becomes most-recently-used again.
+    expect(selector(state, 0, 2)).toBe(keep)
+    // Push a third distinct result: the LRU victim is (1,3), not `keep`.
+    selector(state, 2, 4)
+
+    expect(selector(state, 0, 2)).toBe(keep)
+  })
+
+  test('bounds the cache and lets old results be garbage collected', async () => {
+    const selector = weakMapMemoize(
+      (array: number[], from: number, to: number) => array.slice(from, to),
+      { maxSize: 10 }
+    )
+    const state = Array.from({ length: 10_000 }, (_, i) => i)
+
+    const evictedResult = new WeakRef(selector(state, 2000, 2500))
+
+    // Far more distinct primitive combinations than maxSize.
+    for (let i = 0; i < 10_000; i++) {
+      selector(state, i, i + 100)
+    }
+
+    // The early result has been evicted and can now be reclaimed, even though
+    // `state` (the WeakMap key) and `selector` (the cache owner) stay alive.
+    await expect(evictedResult).toBeGarbageCollected()
+    expect(state.length).toBe(10_000)
+    expect(selector(state, 9999, 10_099)).toEqual(state.slice(9999, 10_099))
+  })
+})

--- a/test/weakMapMemoize.memory.spec.ts
+++ b/test/weakMapMemoize.memory.spec.ts
@@ -1,4 +1,5 @@
-import { weakMapMemoize } from 'reselect'
+import { shallowEqual } from 'react-redux'
+import { createSelector, weakMapMemoize } from 'reselect'
 
 /**
  * Confirmation tests for https://github.com/reduxjs/reselect/issues/635
@@ -132,5 +133,80 @@ describe('weakMapMemoize maxSize (fix for issue #635)', () => {
     await expect(evictedResult).toBeGarbageCollected()
     expect(state.length).toBe(10_000)
     expect(selector(state, 9999, 10_099)).toEqual(state.slice(9999, 10_099))
+  })
+
+  test('evicts object-keyed results as well (WeakMap branch)', () => {
+    const selector = weakMapMemoize(
+      (a: object, b: object) => ({ a, b }),
+      { maxSize: 1 }
+    )
+    const o1 = {}
+    const o2 = {}
+    const o3 = {}
+
+    const first = selector(o1, o2)
+    expect(selector(o1, o2)).toBe(first)
+
+    // Distinct second object exceeds maxSize and evicts (o1, o2).
+    selector(o1, o3)
+
+    expect(selector(o1, o2)).not.toBe(first)
+  })
+
+  test('clearCache resets the bounded cache', () => {
+    const selector = weakMapMemoize(
+      (array: number[], from: number) => array.slice(from),
+      { maxSize: 5 }
+    )
+    const state = [1, 2, 3]
+
+    const first = selector(state, 0)
+    expect(selector(state, 0)).toBe(first)
+
+    selector.clearCache()
+
+    expect(selector(state, 0)).not.toBe(first)
+  })
+
+  test('works together with resultEqualityCheck', () => {
+    const selector = weakMapMemoize(
+      (array: { id: number }[], from: number) =>
+        array.slice(from).map(({ id }) => id),
+      { maxSize: 5, resultEqualityCheck: shallowEqual }
+    )
+
+    const first = selector([{ id: 1 }, { id: 2 }], 0)
+    // New array arg, but shallowly-equal output -> same reference returned.
+    const second = selector([{ id: 1 }, { id: 2 }], 0)
+
+    expect(second).toBe(first)
+    expect(selector.resultsCount()).toBe(1)
+  })
+})
+
+describe('weakMapMemoize maxSize integration with createSelector (issue #635)', () => {
+  test('maxSize on both memoize and argsMemoize bounds the whole selector', () => {
+    // `createSelector` caches twice: `argsMemoize` on the raw selector args and
+    // `memoize` on the extracted input values. Both must be bounded, otherwise
+    // `argsMemoize` short-circuits and keeps every result keyed by the
+    // primitive args alive.
+    const selectSlice = createSelector(
+      [(array: number[]) => array, (_: number[], from: number) => from],
+      (array, from) => array.slice(from),
+      {
+        memoize: weakMapMemoize,
+        memoizeOptions: { maxSize: 2 },
+        argsMemoize: weakMapMemoize,
+        argsMemoizeOptions: { maxSize: 2 }
+      }
+    )
+    const state = [1, 2, 3, 4, 5]
+
+    const first = selectSlice(state, 0)
+    selectSlice(state, 1)
+    selectSlice(state, 2) // exceeds maxSize on both layers -> evicts (state, 0)
+
+    expect(selectSlice(state, 0)).not.toBe(first)
+    expect(selectSlice(state, 0)).toEqual(state.slice(0))
   })
 })

--- a/test/weakMapMemoize.memory.spec.ts
+++ b/test/weakMapMemoize.memory.spec.ts
@@ -2,13 +2,13 @@ import { shallowEqual } from 'react-redux'
 import { createSelector, weakMapMemoize } from 'reselect'
 
 /**
- * Confirmation tests for https://github.com/reduxjs/reselect/issues/635
+ * Characterization tests for https://github.com/reduxjs/reselect/issues/635
  *
  * `weakMapMemoize` stores primitive arguments in strong `Map`s that live inside
  * the cache tree. When the *first* argument is a long-lived object (e.g. the
  * Redux state, or a stable derived value) but later primitive arguments keep
  * changing, every result that was ever computed is retained for as long as that
- * first object stays reachable — an unbounded cache that behaves like a leak.
+ * first object stays reachable, and nothing is evicted.
  *
  * These tests require `node --expose-gc` (already used by the `test` script).
  */
@@ -20,7 +20,7 @@ const makeSliceSelector = (options?: Parameters<typeof weakMapMemoize>[1]) =>
   )
 
 describe('weakMapMemoize unbounded cache (issue #635)', () => {
-  test('retains every result forever while the object arg stays alive (leak)', () => {
+  test('retains every result while the object argument stays alive', () => {
     const selector = makeSliceSelector()
 
     // Long-lived object argument (imagine this is the Redux state).
@@ -33,12 +33,12 @@ describe('weakMapMemoize unbounded cache (issue #635)', () => {
       selector(state, i, i + 100)
     }
 
-    // The very first result is STILL memoized after 10k different calls.
-    // This is the leak: nothing is ever evicted.
+    // The first result is still memoized after 10k different calls, because
+    // nothing is evicted.
     expect(selector(state, 2000, 2500)).toBe(initialResult)
   })
 
-  test('old results are not garbage collected while the object arg is alive (leak)', async () => {
+  test('old results are not garbage collected while the object argument is alive', async () => {
     const selector = makeSliceSelector()
     const state = Array.from({ length: 10_000 }, (_, i) => i)
 
@@ -63,7 +63,9 @@ describe('weakMapMemoize maxSize (fix for issue #635)', () => {
   test('rejects a non-positive-integer maxSize', () => {
     expect(() => makeSliceSelector({ maxSize: 0 })).toThrow(/positive integer/)
     expect(() => makeSliceSelector({ maxSize: -1 })).toThrow(/positive integer/)
-    expect(() => makeSliceSelector({ maxSize: 1.5 })).toThrow(/positive integer/)
+    expect(() => makeSliceSelector({ maxSize: 1.5 })).toThrow(
+      /positive integer/
+    )
   })
 
   test('still caches within the configured size', () => {
@@ -136,10 +138,9 @@ describe('weakMapMemoize maxSize (fix for issue #635)', () => {
   })
 
   test('evicts object-keyed results as well (WeakMap branch)', () => {
-    const selector = weakMapMemoize(
-      (a: object, b: object) => ({ a, b }),
-      { maxSize: 1 }
-    )
+    const selector = weakMapMemoize((a: object, b: object) => ({ a, b }), {
+      maxSize: 1
+    })
     const o1 = {}
     const o2 = {}
     const o3 = {}
@@ -181,6 +182,47 @@ describe('weakMapMemoize maxSize (fix for issue #635)', () => {
 
     expect(second).toBe(first)
     expect(selector.resultsCount()).toBe(1)
+  })
+})
+
+describe('weakMapMemoize treats object and primitive arguments differently', () => {
+  test('results keyed by an object are collected once that object is dropped', async () => {
+    const memoized = weakMapMemoize((source: { id: number }) => ({
+      id: source.id
+    }))
+
+    let key: { id: number } | null = { id: 0 }
+    const result = new WeakRef(memoized(key))
+
+    // The only reference to the `WeakMap` key goes away.
+    key = null
+
+    for (let i = 1; i < 1_000; i++) {
+      memoized({ id: i })
+    }
+
+    await expect(result).toBeGarbageCollected()
+  })
+
+  test('results keyed by a primitive stay reachable until the cache is cleared', async () => {
+    const memoized = weakMapMemoize((id: string) => ({ id }))
+
+    const firstResult = new WeakRef(memoized('item-0'))
+
+    for (let i = 1; i < 1_000; i++) {
+      memoized(`item-${i}`)
+    }
+
+    // The caller kept no reference to either the key or the result, but the
+    // key is a string held by a strong `Map`, so there is nothing for the
+    // garbage collector to observe becoming unreachable. Without a `maxSize`
+    // the entry lives as long as the memoized function does.
+    await expect(firstResult).not.toBeGarbageCollected()
+
+    // Without a bounded cache, the entry is released by clearing the cache.
+    memoized.clearCache()
+
+    await expect(firstResult).toBeGarbageCollected()
   })
 })
 

--- a/type-tests/argsMemoize.test-d.ts
+++ b/type-tests/argsMemoize.test-d.ts
@@ -80,17 +80,13 @@ describe('memoize and argsMemoize', () => {
       todos => todos.map(t => t.id),
       { memoize: weakMapMemoize }
     )
-    // @ts-expect-error When memoize is weakMapMemoize, type of memoizeOptions needs to be the same as options args in weakMapMemoize.
     const selectorWeakMapArgsAsArrayWithMemoizeOptions = createSelector(
       [(state: RootState) => state.todos],
-      // @ts-expect-error
       todos => todos.map(t => t.id),
       { memoize: weakMapMemoize, memoizeOptions: { maxSize: 2 } }
     )
-    // @ts-expect-error When memoize is weakMapMemoize, type of memoizeOptions needs to be the same as options args in weakMapMemoize.
     const selectorWeakMapSeparateInlineArgsWithMemoizeOptions = createSelector(
       (state: RootState) => state.todos,
-      // @ts-expect-error
       todos => todos.map(t => t.id),
       { memoize: weakMapMemoize, memoizeOptions: { maxSize: 2 } }
     )
@@ -113,10 +109,8 @@ describe('memoize and argsMemoize', () => {
       { memoize: lruMemoize }
     )
     const changeMemoizeMethodSelectorDefaultWithMemoizeOptions =
-      // @ts-expect-error When memoize is changed to weakMapMemoize or autotrackMemoize, memoizeOptions cannot be the same type as options args in lruMemoize.
       createSelectorDefault(
         (state: RootState) => state.todos,
-        // @ts-expect-error
         todos => todos.map(t => t.id),
         { memoize: weakMapMemoize, memoizeOptions: { maxSize: 2 } }
       )
@@ -196,17 +190,13 @@ describe('memoize and argsMemoize', () => {
       todos => todos.map(t => t.id),
       { argsMemoize: weakMapMemoize }
     )
-    // @ts-expect-error When argsMemoize is weakMapMemoize, type of argsMemoizeOptions needs to be the same as options args in weakMapMemoize.
     const selectorWeakMapArgsAsArrayWithMemoizeOptions = createSelector(
       [(state: RootState) => state.todos],
-      // @ts-expect-error
       todos => todos.map(t => t.id),
       { argsMemoize: weakMapMemoize, argsMemoizeOptions: { maxSize: 2 } }
     )
-    // @ts-expect-error When argsMemoize is weakMapMemoize, type of argsMemoizeOptions needs to be the same as options args in weakMapMemoize.
     const selectorWeakMapSeparateInlineArgsWithMemoizeOptions = createSelector(
       (state: RootState) => state.todos,
-      // @ts-expect-error
       todos => todos.map(t => t.id),
       { argsMemoize: weakMapMemoize, argsMemoizeOptions: { maxSize: 2 } }
     )
@@ -222,18 +212,14 @@ describe('memoize and argsMemoize', () => {
         argsMemoizeOptions: { maxSize: 2 }
       }
     )
-    // @ts-expect-error When argsMemoize is weakMapMemoize, type of argsMemoizeOptions needs to be the same as options args in weakMapMemoize.
     const selectorWeakMapSeparateInlineArgsWithMemoizeOptions2 = createSelector(
       (state: RootState) => state.todos,
-      // @ts-expect-error
       todos => todos.map(t => t.id),
       {
         memoize: lruMemoize,
         argsMemoize: weakMapMemoize,
         memoizeOptions: {
-          equalityCheck:
-            // @ts-expect-error
-            (a, b) => a === b,
+          equalityCheck: (a, b) => a === b,
           maxSize: 2
         },
         argsMemoizeOptions: { maxSize: 2 }
@@ -244,10 +230,8 @@ describe('memoize and argsMemoize', () => {
       memoize: lruMemoize
     })
     const selectorWeakMapSeparateInlineArgsWithMemoizeOptions3 =
-      // @ts-expect-error When argsMemoize is weakMapMemoize, type of argsMemoizeOptions needs to be the same as options args in weakMapMemoize.
       createSelectorLruMemoize(
         (state: RootState) => state.todos,
-        // @ts-expect-error
         todos => todos.map(t => t.id),
         {
           memoize: lruMemoize,
@@ -255,9 +239,7 @@ describe('memoize and argsMemoize', () => {
           // memoizeOptions: [],
           memoizeOptions: [
             {
-              equalityCheck:
-                // @ts-expect-error
-                (a, b) => a === b,
+              equalityCheck: (a, b) => a === b,
               maxSize: 2
             }
           ],
@@ -321,10 +303,8 @@ describe('memoize and argsMemoize', () => {
       { argsMemoize: lruMemoize }
     )
     const changeMemoizeMethodSelectorDefaultWithMemoizeOptions =
-      // @ts-expect-error When argsMemoize is changed to weakMapMemoize or autotrackMemoize, argsMemoizeOptions cannot be the same type as options args in lruMemoize.
       createSelectorDefault(
         (state: RootState) => state.todos,
-        // @ts-expect-error
         todos => todos.map(t => t.id),
         { argsMemoize: weakMapMemoize, argsMemoizeOptions: { maxSize: 2 } }
       )

--- a/typescript_test/argsMemoize.typetest.ts
+++ b/typescript_test/argsMemoize.typetest.ts
@@ -77,17 +77,13 @@ function overrideOnlyMemoizeInCreateSelector() {
     todos => todos.map(t => t.id),
     { memoize: weakMapMemoize }
   )
-  // @ts-expect-error When memoize is weakMapMemoize, type of memoizeOptions needs to be the same as options args in weakMapMemoize.
   const selectorWeakMapArgsAsArrayWithMemoizeOptions = createSelector(
     [(state: RootState) => state.todos],
-    // @ts-expect-error
     todos => todos.map(t => t.id),
     { memoize: weakMapMemoize, memoizeOptions: { maxSize: 2 } }
   )
-  // @ts-expect-error When memoize is weakMapMemoize, type of memoizeOptions needs to be the same as options args in weakMapMemoize.
   const selectorWeakMapSeparateInlineArgsWithMemoizeOptions = createSelector(
     (state: RootState) => state.todos,
-    // @ts-expect-error
     todos => todos.map(t => t.id),
     { memoize: weakMapMemoize, memoizeOptions: { maxSize: 2 } }
   )
@@ -110,10 +106,8 @@ function overrideOnlyMemoizeInCreateSelector() {
     { memoize: lruMemoize }
   )
   const changeMemoizeMethodSelectorDefaultWithMemoizeOptions =
-    // @ts-expect-error When memoize is changed to weakMapMemoize or autotrackMemoize, memoizeOptions cannot be the same type as options args in lruMemoize.
     createSelectorDefault(
       (state: RootState) => state.todos,
-      // @ts-expect-error
       todos => todos.map(t => t.id),
       { memoize: weakMapMemoize, memoizeOptions: { maxSize: 2 } }
     )
@@ -192,17 +186,13 @@ function overrideOnlyArgsMemoizeInCreateSelector() {
     todos => todos.map(t => t.id),
     { argsMemoize: weakMapMemoize }
   )
-  // @ts-expect-error When argsMemoize is weakMapMemoize, type of argsMemoizeOptions needs to be the same as options args in weakMapMemoize.
   const selectorWeakMapArgsAsArrayWithMemoizeOptions = createSelector(
     [(state: RootState) => state.todos],
-    // @ts-expect-error
     todos => todos.map(t => t.id),
     { argsMemoize: weakMapMemoize, argsMemoizeOptions: { maxSize: 2 } }
   )
-  // @ts-expect-error When argsMemoize is weakMapMemoize, type of argsMemoizeOptions needs to be the same as options args in weakMapMemoize.
   const selectorWeakMapSeparateInlineArgsWithMemoizeOptions = createSelector(
     (state: RootState) => state.todos,
-    // @ts-expect-error
     todos => todos.map(t => t.id),
     { argsMemoize: weakMapMemoize, argsMemoizeOptions: { maxSize: 2 } }
   )
@@ -218,18 +208,14 @@ function overrideOnlyArgsMemoizeInCreateSelector() {
       argsMemoizeOptions: { maxSize: 2 }
     }
   )
-  // @ts-expect-error When argsMemoize is weakMapMemoize, type of argsMemoizeOptions needs to be the same as options args in weakMapMemoize.
   const selectorWeakMapSeparateInlineArgsWithMemoizeOptions2 = createSelector(
     (state: RootState) => state.todos,
-    // @ts-expect-error
     todos => todos.map(t => t.id),
     {
       memoize: lruMemoize,
       argsMemoize: weakMapMemoize,
       memoizeOptions: {
-        equalityCheck:
-          // @ts-expect-error
-          (a, b) => a === b,
+        equalityCheck: (a, b) => a === b,
         maxSize: 2
       },
       argsMemoizeOptions: { maxSize: 2 }
@@ -240,10 +226,8 @@ function overrideOnlyArgsMemoizeInCreateSelector() {
     memoize: lruMemoize
   })
   const selectorWeakMapSeparateInlineArgsWithMemoizeOptions3 =
-    // @ts-expect-error When argsMemoize is weakMapMemoize, type of argsMemoizeOptions needs to be the same as options args in weakMapMemoize.
     createSelectorLruMemoize(
       (state: RootState) => state.todos,
-      // @ts-expect-error
       todos => todos.map(t => t.id),
       {
         memoize: lruMemoize,
@@ -251,9 +235,7 @@ function overrideOnlyArgsMemoizeInCreateSelector() {
         // memoizeOptions: [],
         memoizeOptions: [
           {
-            equalityCheck:
-              // @ts-expect-error
-              (a, b) => a === b,
+            equalityCheck: (a, b) => a === b,
             maxSize: 2
           }
         ],
@@ -304,10 +286,8 @@ function overrideOnlyArgsMemoizeInCreateSelector() {
     { argsMemoize: lruMemoize }
   )
   const changeMemoizeMethodSelectorDefaultWithMemoizeOptions =
-    // @ts-expect-error When argsMemoize is changed to weakMapMemoize or autotrackMemoize, argsMemoizeOptions cannot be the same type as options args in lruMemoize.
     createSelectorDefault(
       (state: RootState) => state.todos,
-      // @ts-expect-error
       todos => todos.map(t => t.id),
       { argsMemoize: weakMapMemoize, argsMemoizeOptions: { maxSize: 2 } }
     )


### PR DESCRIPTION
# feat: add `maxSize` option to `weakMapMemoize` to bound cache growth

Fixes #635

## Problem

`weakMapMemoize` builds a tree of cache nodes keyed by the identity of each
argument. Object/function arguments are stored in `WeakMap`s and are cleaned up
by the garbage collector once the argument becomes unreachable. Primitive
arguments, however, are stored in regular strong `Map`s.

When a selector is called with a long-lived object as the first argument (for
example the Redux state, or a stable value derived by a sub-selector) followed
by ever-changing primitives, every result that was ever computed is retained for
the entire lifetime of that object. Nothing is evicted, so the strong `Map`s
grow without bound — a de-facto memory leak.

```ts
const selector = weakMapMemoize(
  (array: number[], from: number, to: number) => array.slice(from, to)
)

const state = Array.from({ length: 10_000 }, (_, i) => i)
const first = selector(state, 2000, 2500)

for (let i = 0; i < 10_000; i++) selector(state, i, i + 100)

selector(state, 2000, 2500) === first // true — still cached, forever
```

A realistic trigger is an endlessly scrolling list backed by a selector such as
`(state, from, to) => state.items.slice(from, to)`: as `from`/`to` change with
every scroll event, every intermediate slice stays in memory for as long as the
state object is alive.

## Change

Add an opt-in `maxSize` option to `WeakMapMemoizeOptions`:

```ts
weakMapMemoize(fn, { maxSize: 10 })
```

- Caps the number of cached results using a least-recently-used (LRU) policy.
- When the limit is exceeded, the least-recently-used result is evicted and any
  now-empty ancestor `Map` branches are pruned, so the strong primitive `Map`s
  stay bounded and evicted results become eligible for garbage collection.
- Object (`WeakMap`) branches continue to rely on normal garbage collection and
  are not pruned.

### Design notes

- **Backwards compatible and zero-cost when unused.** Without `maxSize` the cache
  is unbounded, exactly as before. The LRU bookkeeping and the extra node
  back-references (`parent`/`map`/`key`) are only maintained when `maxSize` is
  set, so the hot path for existing users is unchanged.
- The default behavior is intentionally left unbounded. Making `weakMapMemoize`
  bounded by default is a separate, breaking decision and is out of scope here.
- `maxSize` is validated to be a positive integer.
- `clearCache()` resets the LRU state.

### Bounding a `createSelector`

`createSelector` memoizes on two levels: `argsMemoize` caches on the raw
selector arguments, and `memoize` caches the result function on the extracted
input values. Both hold results keyed by primitive arguments, so both must be
bounded — otherwise `argsMemoize` short-circuits and the leak remains:

```ts
const selectSlice = createSelector(
  [(state: RootState) => state.items, (_: RootState, from: number) => from],
  (items, from) => items.slice(from),
  {
    memoize: weakMapMemoize,
    memoizeOptions: { maxSize: 10 },
    argsMemoize: weakMapMemoize,
    argsMemoizeOptions: { maxSize: 10 }
  }
)
```

## Tests

`test/weakMapMemoize.memory.spec.ts` adds a `toBeGarbageCollected` matcher
(garbage collection is exposed via `node --expose-gc`, already used by the
`test` script) and covers:

- The unbounded behavior on the current implementation: an old result stays
  cached after many distinct calls and is not collected while the state object
  remains reachable.
- `maxSize` validation.
- Caching within the configured size, LRU eviction once it is exceeded, and a
  recently-used result surviving while a staler one is evicted.
- Eviction of object-keyed results (the `WeakMap` branch), `clearCache()`
  resetting the bounded cache, and coexistence with `resultEqualityCheck`.
- Bounding a full `createSelector` via `maxSize` on both `memoizeOptions` and
  `argsMemoizeOptions`.
- With a small `maxSize` and many distinct primitive combinations, an early
  result is garbage collected while the state object and the selector stay
  alive.
