### PR TITLE
Add regression test for `resultEqualityCheck` receiving a cleared `WeakRef`

### DIFF
--- a/test/weakmapMemoize.spec.ts
+++ b/test/weakmapMemoize.spec.ts
@@ -361,4 +361,53 @@ describe('weakMapMemoize integration with resultEqualityCheck', () => {
       resultEqualityCheck.mockClear()
     }
   )
+
+  // https://github.com/reduxjs/reselect/issues/750
+  // Once the previous result has been garbage-collected, its `WeakRef`
+  // derefs to `undefined`. `resultEqualityCheck` must never receive the
+  // raw `WeakRef` as its previous value.
+  test.skipIf(!global.gc)(
+    'resultEqualityCheck is not called with a cleared WeakRef',
+    async () => {
+      let collected = false
+      const registry = new FinalizationRegistry(() => {
+        collected = true
+      })
+
+      const resultEqualityCheck = vi
+        .fn((a: unknown, b: unknown) => a === b)
+        .mockName('resultEqualityCheck')
+
+      const selectSet = weakMapMemoize(
+        (input: { id: number }) => new Set([input.id]),
+        { resultEqualityCheck }
+      )
+
+      // Produce a result and register it for finalization, then drop every
+      // strong reference to it (and to the argument that keys its cache node)
+      // by keeping them scoped to this IIFE, so it becomes eligible for GC.
+      ;(() => {
+        registry.register(selectSet({ id: 1 }), 1)
+      })()
+
+      // Give the garbage collector several passes, yielding to the event loop
+      // between them so the finalization callback can fire. Once collected,
+      // `lastResult` is a cleared `WeakRef`.
+      for (let i = 0; i < 10 && !collected; i++) {
+        global.gc!()
+        await new Promise(resolve => setTimeout(resolve, 10))
+      }
+
+      expect(collected).toBe(true)
+
+      // Calling the selector again must not forward that cleared `WeakRef`
+      // to `resultEqualityCheck`.
+      selectSet({ id: 2 })
+
+      for (const [previous, next] of resultEqualityCheck.mock.calls) {
+        expect(previous).not.toBeInstanceOf(WeakRef)
+        expect(next).not.toBeInstanceOf(WeakRef)
+      }
+    }
+  )
 })


### PR DESCRIPTION
Closes #750

The bug reported in #750 was actually fixed a while back in cea19b9, where the old `lastResult?.deref?.() ?? lastResult` line was replaced with the `maybeDeref` helper. Once that shipped in 5.2.0 the runtime error is gone.

What was still missing is a test that locks the behavior in, so we don't accidentally regress it again. The original reporter tried to write one but couldn't get garbage collection to trigger reliably.

This adds that test. It builds a memoized selector, produces one result and registers it with a `FinalizationRegistry`, then drops every strong reference so the result becomes collectible. Instead of a single `global.gc()` call (which was flaky and just timed out), it runs a few GC passes and yields to the event loop between them until the finalization callback fires. At that point `lastResult` is a cleared `WeakRef`, and the test asserts that a subsequent call never hands that raw `WeakRef` to `resultEqualityCheck`.

The test is skipped when `global.gc` isn't exposed. I confirmed it fails against the old `?? lastResult` logic and passes with the current `maybeDeref` implementation, so it genuinely guards the fix.
