### PR TITLE
Migrate from Prettier to oxfmt

### DIFF
--- a/.github/workflows/build-and-test-types.yml
+++ b/.github/workflows/build-and-test-types.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run linter
         run: yarn lint
 
+      - name: Check formatting
+        run: yarn format:check
+
       - name: Run tests
         run: yarn test
 

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "arrowParens": "avoid",
+  "printWidth": 80,
+  "sortPackageJson": false,
+  "ignorePatterns": []
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "tabWidth": 2,
-  "trailingComma": "none",
-  "arrowParens": "avoid"
-}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "yarn clean && tsup",
     "clean": "rimraf dist",
-    "format": "prettier --write \"{src,test}/**/*.{js,ts}\" \"docs/**/*.md\"",
+    "format": "oxfmt src test",
+    "format:check": "oxfmt --check src test",
     "lint": "eslint src test",
     "prepack": "yarn build",
     "bench": "vitest --run bench --mode production",
@@ -74,7 +75,7 @@
     "memoize-one": "^6.0.0",
     "micro-memoize": "^4.0.9",
     "netlify-plugin-cache": "^1.0.3",
-    "prettier": "^2.7.1",
+    "oxfmt": "^0.61.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.0.4",

--- a/src/createSelectorCreator.ts
+++ b/src/createSelectorCreator.ts
@@ -384,63 +384,69 @@ export function createSelectorCreator<
     const finalArgsMemoizeOptions = ensureIsArray(argsMemoizeOptions)
     const dependencies = getDependencies(createSelectorArgs) as InputSelectors
 
-    const memoizedResultFunc = memoize(function recomputationWrapper() {
-      recomputations++
-      // apply arguments instead of spreading for performance.
-      // @ts-ignore
-      return (resultFunc as Combiner<InputSelectors, Result>).apply(
-        null,
-        arguments as unknown as Parameters<Combiner<InputSelectors, Result>>
-      )
-    }, ...finalMemoizeOptions) as Combiner<InputSelectors, Result> &
+    const memoizedResultFunc = memoize(
+      function recomputationWrapper() {
+        recomputations++
+        // apply arguments instead of spreading for performance.
+        // @ts-ignore
+        return (resultFunc as Combiner<InputSelectors, Result>).apply(
+          null,
+          arguments as unknown as Parameters<Combiner<InputSelectors, Result>>
+        )
+      },
+      ...finalMemoizeOptions
+    ) as Combiner<InputSelectors, Result> &
       ExtractMemoizerFields<OverrideMemoizeFunction>
 
     let firstRun = true
 
     // If a selector is called with the exact same arguments we don't need to traverse our dependencies again.
-    const selector = argsMemoize(function dependenciesChecker() {
-      dependencyRecomputations++
-      /** Return values of input selectors which the `resultFunc` takes as arguments. */
-      const inputSelectorResults = collectInputSelectorResults(
-        dependencies,
-        arguments
-      )
+    const selector = argsMemoize(
+      function dependenciesChecker() {
+        dependencyRecomputations++
+        /** Return values of input selectors which the `resultFunc` takes as arguments. */
+        const inputSelectorResults = collectInputSelectorResults(
+          dependencies,
+          arguments
+        )
 
-      // apply arguments instead of spreading for performance.
-      // @ts-ignore
-      lastResult = memoizedResultFunc.apply(null, inputSelectorResults)
+        // apply arguments instead of spreading for performance.
+        // @ts-ignore
+        lastResult = memoizedResultFunc.apply(null, inputSelectorResults)
 
-      if (process.env.NODE_ENV !== 'production') {
-        const { devModeChecks = {} } = combinedOptions
-        const { identityFunctionCheck, inputStabilityCheck } =
-          getDevModeChecksExecutionInfo(firstRun, devModeChecks)
-        if (identityFunctionCheck.shouldRun) {
-          identityFunctionCheck.run(
-            resultFunc as Combiner<InputSelectors, Result>,
-            inputSelectorResults,
-            lastResult
-          )
+        if (process.env.NODE_ENV !== 'production') {
+          const { devModeChecks = {} } = combinedOptions
+          const { identityFunctionCheck, inputStabilityCheck } =
+            getDevModeChecksExecutionInfo(firstRun, devModeChecks)
+          if (identityFunctionCheck.shouldRun) {
+            identityFunctionCheck.run(
+              resultFunc as Combiner<InputSelectors, Result>,
+              inputSelectorResults,
+              lastResult
+            )
+          }
+
+          if (inputStabilityCheck.shouldRun) {
+            // make a second copy of the params, to check if we got the same results
+            const inputSelectorResultsCopy = collectInputSelectorResults(
+              dependencies,
+              arguments
+            )
+
+            inputStabilityCheck.run(
+              { inputSelectorResults, inputSelectorResultsCopy },
+              { memoize, memoizeOptions: finalMemoizeOptions },
+              arguments
+            )
+          }
+
+          if (firstRun) firstRun = false
         }
 
-        if (inputStabilityCheck.shouldRun) {
-          // make a second copy of the params, to check if we got the same results
-          const inputSelectorResultsCopy = collectInputSelectorResults(
-            dependencies,
-            arguments
-          )
-
-          inputStabilityCheck.run(
-            { inputSelectorResults, inputSelectorResultsCopy },
-            { memoize, memoizeOptions: finalMemoizeOptions },
-            arguments
-          )
-        }
-
-        if (firstRun) firstRun = false
-      }
-
-      return lastResult
-    }, ...finalArgsMemoizeOptions) as unknown as Selector<
+        return lastResult
+      },
+      ...finalArgsMemoizeOptions
+    ) as unknown as Selector<
       GetStateFromSelectors<InputSelectors>,
       Result,
       GetParamsFromSelectors<InputSelectors>

--- a/src/createStructuredSelector.ts
+++ b/src/createStructuredSelector.ts
@@ -154,7 +154,8 @@ export type TypedStructuredSelectorCreator<RootState = any> =
    * @see {@link https://reselect.js.org/api/createStructuredSelector `createStructuredSelector`}
    */
   <
-    InputSelectorsObject extends RootStateSelectors<RootState> = RootStateSelectors<RootState>,
+    InputSelectorsObject extends RootStateSelectors<RootState> =
+      RootStateSelectors<RootState>,
     MemoizeFunction extends UnknownMemoizer = typeof weakMapMemoize,
     ArgsMemoizeFunction extends UnknownMemoizer = typeof weakMapMemoize
   >(

--- a/src/types.ts
+++ b/src/types.ts
@@ -650,9 +650,11 @@ export type UnionToIntersection<Union> =
         (distributedUnion: Union) => void
       : // This won't happen.
         never
-  ) extends // Infer the `Intersection` type since TypeScript represents the positional
-  // arguments of unions of functions as an intersection of the union.
-  (mergedIntersection: infer Intersection) => void
+  ) extends (
+    // Infer the `Intersection` type since TypeScript represents the positional
+    // arguments of unions of functions as an intersection of the union.
+    mergedIntersection: infer Intersection
+  ) => void
     ? // The `& Union` is to allow indexing by the resulting type
       Intersection & Union
     : never
@@ -670,11 +672,10 @@ type Push<T extends any[], V> = [...T, V]
  *
  * @internal
  */
-type LastOf<T> = UnionToIntersection<
-  T extends any ? () => T : never
-> extends () => infer R
-  ? R
-  : never
+type LastOf<T> =
+  UnionToIntersection<T extends any ? () => T : never> extends () => infer R
+    ? R
+    : never
 
 /**
  * TS4.1+
@@ -790,8 +791,8 @@ export type BuiltIn =
 export type Expand<T> = T extends (...args: infer A) => infer R
   ? (...args: Expand<A>) => Expand<R>
   : T extends infer O
-  ? { [K in keyof O]: O[K] }
-  : never
+    ? { [K in keyof O]: O[K] }
+    : never
 
 /**
  * Expand an item recursively.
@@ -802,10 +803,10 @@ export type Expand<T> = T extends (...args: infer A) => infer R
 export type ExpandRecursively<T> = T extends (...args: infer A) => infer R
   ? (...args: ExpandRecursively<A>) => ExpandRecursively<R>
   : T extends object
-  ? T extends infer O
-    ? { [K in keyof O]: ExpandRecursively<O[K]> }
-    : never
-  : T
+    ? T extends infer O
+      ? { [K in keyof O]: ExpandRecursively<O[K]> }
+      : never
+    : T
 
 /**
  * @internal
@@ -867,10 +868,10 @@ export type ComputeDeep<A, Seen = never> = A extends BuiltIn
             } & unknown)[]
           : A
         : A extends readonly any[]
-        ? A extends readonly Record<PropertyKey, any>[]
-          ? readonly ({
-              [K in keyof A[number]]: ComputeDeep<A[number][K], A | Seen>
-            } & unknown)[]
-          : A
-        : { [K in keyof A]: ComputeDeep<A[K], A | Seen> } & unknown
+          ? A extends readonly Record<PropertyKey, any>[]
+            ? readonly ({
+                [K in keyof A[number]]: ComputeDeep<A[number][K], A | Seen>
+              } & unknown)[]
+            : A
+          : { [K in keyof A]: ComputeDeep<A[K], A | Seen> } & unknown
     >

--- a/src/versionedTypes/ts47-mergeParameters.ts
+++ b/src/versionedTypes/ts47-mergeParameters.ts
@@ -14,11 +14,11 @@ type LongestTuple<ArrayOfTuples extends readonly unknown[][]> =
   ArrayOfTuples extends [infer FirstArray extends unknown[]]
     ? FirstArray
     : ArrayOfTuples extends [
-        infer FirstArray,
-        ...infer RestArrays extends unknown[][]
-      ]
-    ? LongerOfTwo<FirstArray, LongestTuple<RestArrays>>
-    : never
+          infer FirstArray,
+          ...infer RestArrays extends unknown[][]
+        ]
+      ? LongerOfTwo<FirstArray, LongestTuple<RestArrays>>
+      : never
 
 /**
  * Determines the longer of two array types.
@@ -73,8 +73,8 @@ type ElementsAtGivenIndex<
 type Intersect<Tuple extends readonly unknown[]> = Tuple extends []
   ? unknown
   : Tuple extends [infer Head, ...infer Tail]
-  ? Head & Intersect<Tail>
-  : Tuple[number]
+    ? Head & Intersect<Tail>
+    : Tuple[number]
 
 /**
  * Merges a tuple of arrays into a single tuple, intersecting types at each index.

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,6 +460,139 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxfmt/binding-android-arm-eabi@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-android-arm-eabi@npm:0.61.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-android-arm64@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-android-arm64@npm:0.61.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-darwin-arm64@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-darwin-arm64@npm:0.61.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-darwin-x64@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-darwin-x64@npm:0.61.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-freebsd-x64@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-freebsd-x64@npm:0.61.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm-gnueabihf@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-arm-gnueabihf@npm:0.61.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm-musleabihf@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-arm-musleabihf@npm:0.61.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm64-gnu@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-arm64-gnu@npm:0.61.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm64-musl@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-arm64-musl@npm:0.61.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-ppc64-gnu@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-ppc64-gnu@npm:0.61.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-riscv64-gnu@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-riscv64-gnu@npm:0.61.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-riscv64-musl@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-riscv64-musl@npm:0.61.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-s390x-gnu@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-s390x-gnu@npm:0.61.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-x64-gnu@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-x64-gnu@npm:0.61.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-x64-musl@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-linux-x64-musl@npm:0.61.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-openharmony-arm64@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-openharmony-arm64@npm:0.61.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-arm64-msvc@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-win32-arm64-msvc@npm:0.61.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-ia32-msvc@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-win32-ia32-msvc@npm:0.61.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-x64-msvc@npm:0.61.0":
+  version: 0.61.0
+  resolution: "@oxfmt/binding-win32-x64-msvc@npm:0.61.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -3704,6 +3837,83 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxfmt@npm:^0.61.0":
+  version: 0.61.0
+  resolution: "oxfmt@npm:0.61.0"
+  dependencies:
+    "@oxfmt/binding-android-arm-eabi": "npm:0.61.0"
+    "@oxfmt/binding-android-arm64": "npm:0.61.0"
+    "@oxfmt/binding-darwin-arm64": "npm:0.61.0"
+    "@oxfmt/binding-darwin-x64": "npm:0.61.0"
+    "@oxfmt/binding-freebsd-x64": "npm:0.61.0"
+    "@oxfmt/binding-linux-arm-gnueabihf": "npm:0.61.0"
+    "@oxfmt/binding-linux-arm-musleabihf": "npm:0.61.0"
+    "@oxfmt/binding-linux-arm64-gnu": "npm:0.61.0"
+    "@oxfmt/binding-linux-arm64-musl": "npm:0.61.0"
+    "@oxfmt/binding-linux-ppc64-gnu": "npm:0.61.0"
+    "@oxfmt/binding-linux-riscv64-gnu": "npm:0.61.0"
+    "@oxfmt/binding-linux-riscv64-musl": "npm:0.61.0"
+    "@oxfmt/binding-linux-s390x-gnu": "npm:0.61.0"
+    "@oxfmt/binding-linux-x64-gnu": "npm:0.61.0"
+    "@oxfmt/binding-linux-x64-musl": "npm:0.61.0"
+    "@oxfmt/binding-openharmony-arm64": "npm:0.61.0"
+    "@oxfmt/binding-win32-arm64-msvc": "npm:0.61.0"
+    "@oxfmt/binding-win32-ia32-msvc": "npm:0.61.0"
+    "@oxfmt/binding-win32-x64-msvc": "npm:0.61.0"
+    tinypool: "npm:2.1.0"
+  peerDependencies:
+    svelte: ^5.0.0
+    vite-plus: "*"
+  dependenciesMeta:
+    "@oxfmt/binding-android-arm-eabi":
+      optional: true
+    "@oxfmt/binding-android-arm64":
+      optional: true
+    "@oxfmt/binding-darwin-arm64":
+      optional: true
+    "@oxfmt/binding-darwin-x64":
+      optional: true
+    "@oxfmt/binding-freebsd-x64":
+      optional: true
+    "@oxfmt/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxfmt/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxfmt/binding-linux-arm64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-arm64-musl":
+      optional: true
+    "@oxfmt/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-riscv64-musl":
+      optional: true
+    "@oxfmt/binding-linux-s390x-gnu":
+      optional: true
+    "@oxfmt/binding-linux-x64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-x64-musl":
+      optional: true
+    "@oxfmt/binding-openharmony-arm64":
+      optional: true
+    "@oxfmt/binding-win32-arm64-msvc":
+      optional: true
+    "@oxfmt/binding-win32-ia32-msvc":
+      optional: true
+    "@oxfmt/binding-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    svelte:
+      optional: true
+    vite-plus:
+      optional: true
+  bin:
+    oxfmt: bin/oxfmt
+  checksum: 10/f56008293b74d7eaabef6dc89fcf992a3f7eabfa5f394283332d529d6875f66b22f9168ef89c7fd4ce10a103322020e2c037915553fce47be98111711e1e9b2f
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
@@ -3920,15 +4130,6 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 10/0b9d2c76801ca652a7f64892dd37b7e3fab149a37d2424920099bf894acccc62abb4424af2155ab36dea8744843060a2d8ddc983518d0b1e22265a22324b72ed
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^2.7.1":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
   languageName: node
   linkType: hard
 
@@ -4211,7 +4412,7 @@ __metadata:
     memoize-one: "npm:^6.0.0"
     micro-memoize: "npm:^4.0.9"
     netlify-plugin-cache: "npm:^1.0.3"
-    prettier: "npm:^2.7.1"
+    oxfmt: "npm:^0.61.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-redux: "npm:^9.0.4"
@@ -4983,6 +5184,13 @@ __metadata:
     fdir: "npm:^6.4.3"
     picomatch: "npm:^4.0.2"
   checksum: 10/4ad28701fa9118b32ef0e27f409e0a6c5741e8b02286d50425c1f6f71e6d6c6ded9dd5bbbbb714784b08623c4ec4d150151f1d3d996cfabe0495f908ab4f7002
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:2.1.0":
+  version: 2.1.0
+  resolution: "tinypool@npm:2.1.0"
+  checksum: 10/c11cfe84e8147d5bf198fe04ea789c068dfa8656c7f3483c76a7408c02d108b2e07d7301458021a0a98952d4a760efb6212ab49a01bac085c4aed3d6ee40ab2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This replaces Prettier with [oxfmt](https://oxc.rs/docs/guide/usage/formatter), the formatter from the Oxc project. oxfmt is Prettier-compatible but written in Rust, so it's dramatically faster and lets us drop Prettier from the dependency tree.

## What changed

The config was generated with oxfmt's built-in `--migrate=prettier`, so `.oxfmtrc.json` carries over every setting from the old `.prettierrc.json` one to one — no semicolons, single quotes, two-space indent, no trailing commas, avoid arrow parens. The migration also picked up that `printWidth` wasn't set and pinned it to Prettier's default of 80 (oxfmt's own default is 100), which keeps the wrapping identical instead of reflowing the whole codebase. The old `.prettierrc.json` is gone, `prettier` is swapped for `oxfmt` in devDependencies, and the `format` script now runs `oxfmt src test`. There was no `.prettierignore`, and oxfmt reads `.gitignore` on its own, so nothing was lost there.

I also added a `format:check` script and wired it into CI right after the lint step. Formatting was never actually enforced before — Prettier only ran locally in `--write` mode — so this closes that gap and stops unformatted code from slipping in.

## Reformatting

oxfmt is close enough to the current Prettier output that only four files in `src` change, and those are the usual Prettier v2 to v3 differences in how nested ternaries and broken-up call arguments are indented (the repo was still on `prettier@2`). Running the formatter is idempotent afterwards.

One spot needed a manual touch: in `src/types.ts` there were two line comments sitting between `extends` and the function type, and oxfmt collapsed them onto one line and flipped their order, which turned them into nonsense. I moved the comment inside the parentheses as a leading comment on the parameter — a position the formatter handles cleanly — without changing the type itself.
