### PR TITLE
perf(weakMapMemoize): return on a cache hit instead of rewriting the node

### DIFF
--- a/src/weakMapMemoize.ts
+++ b/src/weakMapMemoize.ts
@@ -239,40 +239,41 @@ export function weakMapMemoize<Func extends AnyFunction>(
       }
     }
 
+    // Return here rather than falling through to the writes below. Both would be
+    // no-ops — `s` is already `TERMINATED` and `v` already holds this result —
+    // but `v` stores a pointer, so re-storing it costs a GC write barrier on a
+    // call that had nothing to record.
+    if (cacheNode.s === TERMINATED) {
+      return cacheNode.v
+    }
+
     const terminatedNode = cacheNode as unknown as TerminatedCacheNode<any>
 
-    let result
+    // Allow errors to propagate
+    let result = func.apply(null, arguments as unknown as any[])
+    resultsCount++
 
-    if (cacheNode.s === TERMINATED) {
-      result = cacheNode.v
-    } else {
-      // Allow errors to propagate
-      result = func.apply(null, arguments as unknown as any[])
-      resultsCount++
+    if (resultEqualityCheck) {
+      // Deref lastResult if it is a Ref
+      const lastResultValue = maybeDeref(lastResult)
 
-      if (resultEqualityCheck) {
-        // Deref lastResult if it is a Ref
-        const lastResultValue = maybeDeref(lastResult)
+      if (
+        lastResultValue != null &&
+        resultEqualityCheck(lastResultValue as ReturnType<Func>, result)
+      ) {
+        result = lastResultValue
 
-        if (
-          lastResultValue != null &&
-          resultEqualityCheck(lastResultValue as ReturnType<Func>, result)
-        ) {
-          result = lastResultValue
-
-          resultsCount !== 0 && resultsCount--
-        }
-
-        const needsWeakRef =
-          (typeof result === 'object' && result !== null) ||
-          typeof result === 'function'
-
-        lastResult = needsWeakRef ? /* @__PURE__ */ new Ref(result) : result
+        resultsCount !== 0 && resultsCount--
       }
+
+      const needsWeakRef =
+        (typeof result === 'object' && result !== null) ||
+        typeof result === 'function'
+
+      lastResult = needsWeakRef ? /* @__PURE__ */ new Ref(result) : result
     }
 
     terminatedNode.s = TERMINATED
-
     terminatedNode.v = result
     return result
   }


### PR DESCRIPTION
On a cache hit `memoized` reads the result out of the node and then falls through to the same two writes a miss does:

```js
if (cacheNode.s === TERMINATED) {
  result = cacheNode.v
} else {
  // ...compute
}
terminatedNode.s = TERMINATED
terminatedNode.v = result
```

Both are no-ops on that path — `s` is already `TERMINATED` and `v` already holds exactly the result we just read out of it. The `v` write isn't free, though: it stores a pointer into a heap object, so it costs a GC write barrier on a call that had nothing to record. This returns early instead.

The diff looks bigger than it is — the `else` branch loses a level of indentation.

Measured with the harness from #770 (paired against `master` in one process, min of 15 interleaved rounds, ns/call):

| case | before | after | |
|---|--:|--:|--:|
| 1 input, `(state)` | 12.0 | 11.1 | 1.08x |
| nested (2 output selectors) | 12.3 | 11.5 | 1.06x |
| 3 inputs, `(state)` | 11.8 | 11.3 | 1.05x |
| 1 input, `(state, props)` | 177.1 | 176.2 | noise |
| same, `argsMemoize: lruMemoize` | 78.2 | 75.2 | noise |

Only the hit path moves, which is what you'd expect: the parametric cases never hit the argument cache (new state every tick, different props every call), so there's no redundant write to skip there. Recomputation counts are identical everywhere, so it's the same work either way.
