### PR TITLE
perf(createSelector): stop allocating dev-check bookkeeping on every call

### DIFF
--- a/src/createSelectorCreator.ts
+++ b/src/createSelectorCreator.ts
@@ -16,12 +16,14 @@ import type {
   UnknownMemoizer
 } from './types'
 
+import { runIdentityFunctionCheck } from './devModeChecks/identityFunctionCheck'
+import { runInputStabilityCheck } from './devModeChecks/inputStabilityCheck'
+import { globalDevModeChecks } from './devModeChecks/setGlobalDevModeChecks'
 import {
   assertIsFunction,
   collectInputSelectorResults,
   ensureIsArray,
-  getDependencies,
-  getDevModeChecksExecutionInfo
+  getDependencies
 } from './utils'
 
 /**
@@ -411,25 +413,55 @@ export function createSelectorCreator<
       lastResult = memoizedResultFunc.apply(null, inputSelectorResults)
 
       if (process.env.NODE_ENV !== 'production') {
-        const { devModeChecks = {} } = combinedOptions
-        const { identityFunctionCheck, inputStabilityCheck } =
-          getDevModeChecksExecutionInfo(firstRun, devModeChecks)
-        if (identityFunctionCheck.shouldRun) {
-          identityFunctionCheck.run(
+        // Resolved without building the four objects `getDevModeChecksExecutionInfo`
+        // returns. This runs on every dependency recomputation, and by default both
+        // checks are `'once'` — so from the second one onwards those objects were
+        // allocated only to be read for two booleans and discarded.
+        //
+        // `hasOwnProperty` rather than `??`, to keep the semantics of the spread
+        // this replaces: an override that explicitly sets a check to `undefined`
+        // silences it, where `??` would fall back to the global setting. The
+        // common case has no overrides at all and reads the global directly.
+        const { devModeChecks } = combinedOptions
+        const identityFunctionCheck =
+          devModeChecks !== undefined &&
+          Object.prototype.hasOwnProperty.call(
+            devModeChecks,
+            'identityFunctionCheck'
+          )
+            ? devModeChecks.identityFunctionCheck
+            : globalDevModeChecks.identityFunctionCheck
+        const inputStabilityCheck =
+          devModeChecks !== undefined &&
+          Object.prototype.hasOwnProperty.call(
+            devModeChecks,
+            'inputStabilityCheck'
+          )
+            ? devModeChecks.inputStabilityCheck
+            : globalDevModeChecks.inputStabilityCheck
+
+        if (
+          identityFunctionCheck === 'always' ||
+          (identityFunctionCheck === 'once' && firstRun)
+        ) {
+          runIdentityFunctionCheck(
             resultFunc as Combiner<InputSelectors, Result>,
             inputSelectorResults,
             lastResult
           )
         }
 
-        if (inputStabilityCheck.shouldRun) {
+        if (
+          inputStabilityCheck === 'always' ||
+          (inputStabilityCheck === 'once' && firstRun)
+        ) {
           // make a second copy of the params, to check if we got the same results
           const inputSelectorResultsCopy = collectInputSelectorResults(
             dependencies,
             arguments
           )
 
-          inputStabilityCheck.run(
+          runInputStabilityCheck(
             { inputSelectorResults, inputSelectorResultsCopy },
             { memoize, memoizeOptions: finalMemoizeOptions },
             arguments

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,4 @@
-import { runIdentityFunctionCheck } from './devModeChecks/identityFunctionCheck'
-import { runInputStabilityCheck } from './devModeChecks/inputStabilityCheck'
-import { globalDevModeChecks } from './devModeChecks/setGlobalDevModeChecks'
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import type {
-  DevModeChecks,
-  Selector,
-  SelectorArray,
-  DevModeChecksExecutionInfo
-} from './types'
+import type { Selector, SelectorArray } from './types'
 
 export const NOT_FOUND = /* @__PURE__ */ Symbol('NOT_FOUND')
 export type NOT_FOUND_TYPE = typeof NOT_FOUND
@@ -122,35 +113,4 @@ export function collectInputSelectorResults(
     inputSelectorResults.push(dependencies[i].apply(null, inputSelectorArgs))
   }
   return inputSelectorResults
-}
-
-/**
- * Retrieves execution information for development mode checks.
- *
- * @param devModeChecks - Custom Settings for development mode checks. These settings will override the global defaults.
- * @param firstRun - Indicates whether it is the first time the selector has run.
- * @returns  An object containing the execution information for each development mode check.
- */
-export const getDevModeChecksExecutionInfo = (
-  firstRun: boolean,
-  devModeChecks: Partial<DevModeChecks>
-) => {
-  const { identityFunctionCheck, inputStabilityCheck } = {
-    ...globalDevModeChecks,
-    ...devModeChecks
-  }
-  return {
-    identityFunctionCheck: {
-      shouldRun:
-        identityFunctionCheck === 'always' ||
-        (identityFunctionCheck === 'once' && firstRun),
-      run: runIdentityFunctionCheck
-    },
-    inputStabilityCheck: {
-      shouldRun:
-        inputStabilityCheck === 'always' ||
-        (inputStabilityCheck === 'once' && firstRun),
-      run: runInputStabilityCheck
-    }
-  } satisfies DevModeChecksExecutionInfo
 }

--- a/test/identityFunctionCheck.test.ts
+++ b/test/identityFunctionCheck.test.ts
@@ -166,6 +166,26 @@ describe('identityFunctionCheck', () => {
     expect(consoleSpy).toHaveBeenCalledOnce()
   })
 
+  localTest(
+    'never runs when the check is explicitly set to undefined',
+    ({ state }) => {
+      // An explicit `undefined` silences the check rather than falling back to
+      // the global setting, because it is a present key that overrides the
+      // default with a frequency that is neither 'once' nor 'always'.
+      const badSelector = createSelector(
+        [(state: RootState) => state],
+        identityFunction,
+        { devModeChecks: { identityFunctionCheck: undefined } }
+      )
+
+      expect(badSelector(state)).toBe(state)
+
+      expect(identityFunction).toHaveBeenCalledOnce()
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+    }
+  )
+
   localTest('uses the memoize provided', ({ state }) => {
     const badSelector = createSelector(
       [(state: RootState) => state.todos],


### PR DESCRIPTION
The dev-mode checks live inside the hot path, and `getDevModeChecksExecutionInfo` builds four objects — a spread, a wrapper, and one per check — every time a selector recomputes its dependencies. Both checks default to `'once'`, so from the second recomputation onwards all four are allocated, read for two booleans, and thrown away.

This resolves the two frequencies in place and calls the check functions directly. `getDevModeChecksExecutionInfo` has no callers left, so it goes; the public `DevModeChecksExecutionInfo` type stays. Production is unaffected — the whole change sits inside the `NODE_ENV !== 'production'` guard.

One thing worth a look in review: I used `hasOwnProperty` rather than `??`. The spread this replaces means `devModeChecks: { identityFunctionCheck: undefined }` *silences* the check — it's a present key overriding the default with a frequency that's neither `'once'` nor `'always'` — where `??` would fall back to the global setting and turn it back on. That edge wasn't covered, so there's a test for it now, and it does fail with `??`. The common case has no overrides and reads the global directly, no `hasOwnProperty` call at all.

Measured with the harness from #770, dev mode (`yarn bench:hot-path:dev`), paired against `master` in one process, ns/call:

| case | before | after | |
|---|--:|--:|--:|
| 3 inputs, `(state, props)` | 251.5 | 217.8 | 1.15x |
| 1 input, `(state, props)` | 203.7 | 179.4 | 1.14x |
| 6 inputs, `(state, props)` | 355.4 | 317.7 | 1.12x |
| same as second, `argsMemoize: lruMemoize` | 89.9 | 80.7 | 1.11x |
| 1 input, `(state)` | 12.4 | 11.9 | noise |
| nested (2 output selectors) | 12.9 | 12.7 | noise |

Dev mode was costing 20–27% over production on the parametric cases; it's now roughly 12–20%. The last two rows are selectors called with the state alone — they hit the argument cache, so they don't recompute dependencies and there's nothing here to skip. Recomputation counts are identical throughout.
