### PR TITLE
Fix assorted memoization correctness issues

### DIFF
--- a/src/devModeChecks/inputStabilityCheck.ts
+++ b/src/devModeChecks/inputStabilityCheck.ts
@@ -1,6 +1,30 @@
 import type { CreateSelectorOptions, UnknownMemoizer } from '../types'
 
 /**
+ * Removes `resultEqualityCheck` from a memoize options object, if present.
+ *
+ * The stability check memoizes a probe function that returns a new empty object
+ * on every call. A `resultEqualityCheck` has no bearing on whether the memoizer
+ * considers the *arguments* equal, but leaving it in place means the user's
+ * function is called with those empty probe objects, and a value-based check
+ * such as `shallowEqual` would report them as equal and suppress the warning.
+ *
+ * @internal
+ */
+const withoutResultEqualityCheck = (option: unknown) => {
+  if (
+    option === null ||
+    typeof option !== 'object' ||
+    !('resultEqualityCheck' in option)
+  ) {
+    return option
+  }
+  const optionCopy: { resultEqualityCheck?: unknown } = { ...option }
+  delete optionCopy.resultEqualityCheck
+  return optionCopy
+}
+
+/**
  * Runs a stability check to ensure the input selector results remain stable
  * when provided with the same arguments. This function is designed to detect
  * changes in the output of input selectors, which can impact the performance of memoized selectors.
@@ -30,7 +54,12 @@ export const runInputStabilityCheck = (
   const { memoize, memoizeOptions } = options
   const { inputSelectorResults, inputSelectorResultsCopy } =
     inputSelectorResultsObject
-  const createAnEmptyObject = memoize(() => ({}), ...memoizeOptions)
+  const probeMemoizeOptions: unknown[] = []
+  const { length } = memoizeOptions
+  for (let i = 0; i < length; i++) {
+    probeMemoizeOptions.push(withoutResultEqualityCheck(memoizeOptions[i]))
+  }
+  const createAnEmptyObject = memoize(() => ({}), ...probeMemoizeOptions)
   // if the memoize method thinks the parameters are equal, these *should* be the same reference
   const areInputSelectorResultsEqual =
     createAnEmptyObject.apply(null, inputSelectorResults) ===

--- a/src/lruMemoize.ts
+++ b/src/lruMemoize.ts
@@ -71,13 +71,13 @@ function createLruCache(maxSize: number, equals: EqualityFn): Cache {
     return NOT_FOUND
   }
 
+  // Only ever called after `get` has returned `NOT_FOUND` for the same key,
+  // so there is no need to search the entries again here.
   function put(key: unknown, value: unknown) {
-    if (get(key) === NOT_FOUND) {
-      // TODO Is unshift slow?
-      entries.unshift({ key, value })
-      if (entries.length > maxSize) {
-        entries.pop()
-      }
+    // TODO Is unshift slow?
+    entries.unshift({ key, value })
+    if (entries.length > maxSize) {
+      entries.pop()
     }
   }
 

--- a/src/lruMemoize.ts
+++ b/src/lruMemoize.ts
@@ -52,7 +52,7 @@ function createLruCache(maxSize: number, equals: EqualityFn): Cache {
   let entries: Entry[] = []
 
   function get(key: unknown) {
-    const cacheIndex = entries.findIndex(entry => equals(key, entry.key))
+    const cacheIndex = entries.findIndex(entry => equals(entry.key, key))
 
     // We found a cached entry
     if (cacheIndex > -1) {

--- a/test/inputStabilityCheck.spec.ts
+++ b/test/inputStabilityCheck.spec.ts
@@ -1,9 +1,11 @@
 import { shallowEqual } from 'react-redux'
+import type { MockInstance } from 'vitest'
 import {
   createSelector,
   lruMemoize,
   referenceEqualityCheck,
-  setGlobalDevModeChecks
+  setGlobalDevModeChecks,
+  weakMapMemoize
 } from 'reselect'
 import type { RootState } from './testUtils'
 import { localTest } from './testUtils'
@@ -272,4 +274,70 @@ describe('the effects of inputStabilityCheck with resultEqualityCheck', () => {
       expect(resultEqualityCheck).not.toHaveBeenCalled()
     }
   )
+
+  const expectStabilityWarning = (consoleSpy: MockInstance) => {
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('An input selector returned a different result'),
+      expect.anything()
+    )
+  }
+
+  for (const inputStabilityCheck of ['once', 'always'] as const) {
+    localTest(
+      `resultEqualityCheck should not be called with empty objects when inputStabilityCheck is set to ${inputStabilityCheck} and input selectors are unstable`,
+      ({ store }) => {
+        const consoleSpy = vi
+          .spyOn(console, 'warn')
+          .mockImplementation(() => {})
+
+        const selectTodoIds = createAppSelector(
+          [state => [...state.todos]],
+          todos => todos.map(({ id }) => id),
+          {
+            memoizeOptions: { resultEqualityCheck },
+            devModeChecks: { inputStabilityCheck }
+          }
+        )
+
+        selectTodoIds(store.getState())
+        selectTodoIds(store.getState())
+
+        for (const [a, b] of resultEqualityCheck.mock.calls) {
+          expect(a).toBeInstanceOf(Array)
+          expect(b).toBeInstanceOf(Array)
+        }
+
+        expectStabilityWarning(consoleSpy)
+
+        consoleSpy.mockRestore()
+      }
+    )
+  }
+
+  for (const memoize of [weakMapMemoize, lruMemoize]) {
+    localTest(
+      `inputStabilityCheck still warns when ${memoize.name} is given a resultEqualityCheck that treats the probe objects as equal`,
+      ({ store }) => {
+        const consoleSpy = vi
+          .spyOn(console, 'warn')
+          .mockImplementation(() => {})
+
+        const selectTodoIds = createAppSelector(
+          [state => [...state.todos]],
+          todos => todos.map(({ id }) => id),
+          {
+            memoize,
+            memoizeOptions: { resultEqualityCheck: shallowEqual },
+            devModeChecks: { inputStabilityCheck: 'always' }
+          }
+        )
+
+        selectTodoIds(store.getState())
+
+        expectStabilityWarning(consoleSpy)
+
+        consoleSpy.mockRestore()
+      }
+    )
+  }
 })

--- a/test/lruMemoize.test.ts
+++ b/test/lruMemoize.test.ts
@@ -752,3 +752,33 @@ describe('lruMemoize integration with resultEqualityCheck', () => {
     }
   )
 })
+
+describe('lruMemoize equalityCheck argument order', () => {
+  for (const maxSize of [1, 2]) {
+    test(`passes (cachedArg, newArg) to equalityCheck with maxSize ${maxSize}`, () => {
+      const recordedCalls: [unknown, unknown][] = []
+
+      const equalityCheck = (a: unknown, b: unknown) => {
+        recordedCalls.push([a, b])
+        return a === b
+      }
+
+      const memoized = lruMemoize((value: string) => value, {
+        equalityCheck,
+        maxSize
+      })
+
+      expect(memoized('first')).toBe('first')
+
+      expect(recordedCalls).toHaveLength(0)
+
+      expect(memoized('second')).toBe('second')
+
+      expect(recordedCalls.length).toBeGreaterThan(0)
+
+      for (const recordedCall of recordedCalls) {
+        expect(recordedCall).toStrictEqual(['first', 'second'])
+      }
+    })
+  }
+})

--- a/test/lruMemoize.test.ts
+++ b/test/lruMemoize.test.ts
@@ -782,3 +782,23 @@ describe('lruMemoize equalityCheck argument order', () => {
     })
   }
 })
+
+describe('lruMemoize cache miss comparison count', () => {
+  test('compares a new argument against each cached entry only once', () => {
+    const equalityCheck = vi.fn(referenceEqualityCheck)
+
+    const memoized = lruMemoize((value: string) => value, {
+      equalityCheck,
+      maxSize: 3
+    })
+
+    memoized('a')
+    memoized('b')
+
+    equalityCheck.mockClear()
+
+    expect(memoized('c')).toBe('c')
+
+    expect(equalityCheck).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
This PR:

- Fixes the accidentally-swapped order of args to the equality check in `lruMemoize`
- Removes use of equality checks from the dev stability probe
- Removes an unnecessary call to `get(key)` in `put()` - that's internal and we only ever call `put` after we've already done that `get` call, so it's duplicate work

Fixes #693 
Supersedes #758 
Supersedes #759 

The extra `get()` call didn't have an issue, just noticed working on these.