### PR TITLE
Improve perf harness

### DIFF
--- a/bench/build.mjs
+++ b/bench/build.mjs
@@ -11,11 +11,14 @@
  *
  * `NODE_ENV` is substituted at build time: the dev-mode checks sit in the hot
  * path, and leaving them in would price a branch no shipped call takes.
+ *
+ * Usage:
+ *   node bench/build.mjs [--baseline=<ref>] [--dev] [--no-minify]
  */
 import { execFileSync } from 'node:child_process'
 import { existsSync, rmSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { build } from 'esbuild'
+import { rolldown } from 'rolldown'
 
 // `fileURLToPath`, not `URL#pathname` — the latter is not a valid filesystem path
 // on every platform.
@@ -29,23 +32,41 @@ const BASELINE_REF =
 // on its own — a production build compiles them out and cannot show it.
 const NODE_ENV = process.argv.includes('--dev') ? 'development' : 'production'
 
+// Minified by default, because that is the shape the published production builds
+// ship in and an unminified bundle is measurably not the same program: with
+// esbuild, substituting `NODE_ENV` folded the dev-mode guard to `if (false)` but
+// left the whole block in the bundle text, keeping every function it referenced
+// alive. Turn it off with `--no-minify` when profiling, where the function names
+// are the point.
+const MINIFY = !process.argv.includes('--no-minify')
+
 const BUILD_DIR = resolve('./.build')
 const BASE_WORKTREE = resolve('./.build/base')
 
 const git = (...args) =>
   execFileSync('git', args, { cwd: resolve('..'), encoding: 'utf8' }).trim()
 
-const bundle = (entry, outfile) =>
-  build({
-    entryPoints: [entry],
-    outfile,
-    bundle: true,
-    format: 'esm',
+async function bundle(entry, outfile) {
+  const built = await rolldown({
+    input: entry,
     platform: 'node',
-    target: 'node20',
-    define: { 'process.env.NODE_ENV': JSON.stringify(NODE_ENV) },
-    logLevel: 'warning'
+    // `transform.define`, not a top-level `define` — rolldown accepts the latter
+    // silently as an unknown key and substitutes nothing, which produces a
+    // bundle that still branches on `process.env.NODE_ENV` at run time.
+    transform: { define: { 'process.env.NODE_ENV': JSON.stringify(NODE_ENV) } }
   })
+
+  await built.write({
+    file: outfile,
+    format: 'esm',
+    minify: MINIFY,
+    // Cheap, and `--enable-source-maps` needs it to report a useful stack out of
+    // a minified bundle.
+    sourcemap: true
+  })
+
+  await built.close()
+}
 
 function prepareBaselineWorktree() {
   if (existsSync(BASE_WORKTREE)) {
@@ -66,17 +87,23 @@ prepareBaselineWorktree()
 
 const baselineSha = git('rev-parse', '--short', BASELINE_REF)
 
-await Promise.all([
-  bundle(resolve('../src/index.ts'), `${BUILD_DIR}/reselect.mjs`),
-  bundle(`${BASE_WORKTREE}/src/index.ts`, `${BUILD_DIR}/reselect-base.mjs`)
-])
+// Sequential, not concurrent: rolldown does its work on a native thread pool, so
+// running both at once gains little, and a shared pool made the failure output of
+// whichever bundle broke impossible to attribute.
+await bundle(resolve('../src/index.ts'), `${BUILD_DIR}/reselect.mjs`)
+await bundle(`${BASE_WORKTREE}/src/index.ts`, `${BUILD_DIR}/reselect-base.mjs`)
 
-// The worktree is only needed until esbuild has read it.
+// The worktree is only needed until rolldown has read it.
 git('worktree', 'remove', '--force', BASE_WORKTREE)
 
 // Recorded so the run reports what it measured. A dev-mode run otherwise looks
 // exactly like a production one in the output, and the two are not comparable.
 writeFileSync(
   `${BUILD_DIR}/meta.json`,
-  JSON.stringify({ nodeEnv: NODE_ENV, baselineRef: BASELINE_REF, baselineSha })
+  JSON.stringify({
+    nodeEnv: NODE_ENV,
+    minified: MINIFY,
+    baselineRef: BASELINE_REF,
+    baselineSha
+  })
 )

--- a/bench/cases.mjs
+++ b/bench/cases.mjs
@@ -11,13 +11,37 @@ import { project } from './workload.mjs'
  * round. Every case exposes `run(state, props)` and a `recomputations()` counter
  * — a variant that looks fast because it silently skips work would otherwise read
  * as a win, and the count is the only thing that rules that out.
+ *
+ * Two kinds of case:
+ *
+ *   - `tick` replays the immutable-update workload in `workload.mjs`. This is the
+ *     realistic shape, and the clock covers the state-producing step too (see
+ *     `run.mjs` for why).
+ *   - `micro` calls one memoized function in a bare loop with no state
+ *     production. A change worth 1-2 ns inside `weakMapMemoize` is a rounding
+ *     error once a 25 ns selector call and a `applyTick` share the measurement,
+ *     so the tick cases cannot see it at all. These can, at the cost of measuring
+ *     something no application does verbatim.
+ *
+ * `expected(ticks, config)` returns the recomputation count the case must report.
+ * It is a function of the tick count because the harness calibrates that per case
+ * rather than fixing it globally.
  */
 
 /* 1 input, 1 argument — the common shape. Every caller within a tick passes the
  * same state, so `argsMemoize` hits on all but the tick's first call. */
 
+/** Once for the priming pass, then once per tick. */
+const oncePerTick = ticks => 1 + ticks
+
+/** Once per priming call, then once per changed entity per tick. */
+const oncePerChangedEntity = (ticks, config) =>
+  config.callsPerTick + ticks * config.changedPerTick
+
 const oneInput = {
   name: '1 input, (state)',
+  kind: 'tick',
+  expected: oncePerTick,
   // Arity matters as much as the selector: `argsMemoize` keys on the whole
   // argument list, so passing a slice selector a per-call props object turns
   // every hit into a miss. It moved this case from 9 ns to 141 ns when the
@@ -38,6 +62,8 @@ const oneInput = {
 
 const threeInputs = {
   name: '3 inputs, (state)',
+  kind: 'tick',
+  expected: oncePerTick,
   arity: 1,
   create: ({ createSelector }, count) =>
     createSelector(
@@ -59,6 +85,8 @@ const selectEntity = (state, props) => state.entities[props.id]
 
 const parametric = {
   name: '1 input, (state, props)',
+  kind: 'tick',
+  expected: oncePerChangedEntity,
   arity: 2,
   create: ({ createSelector }, count) =>
     createSelector([selectEntity], entity => {
@@ -69,6 +97,8 @@ const parametric = {
 
 const parametricLruArgs = {
   name: '  same, lru argsMemoize',
+  kind: 'tick',
+  expected: oncePerChangedEntity,
   arity: 2,
   create: ({ createSelector, lruMemoize }, count) =>
     createSelector(
@@ -86,6 +116,8 @@ const parametricLruArgs = {
 
 const nested = {
   name: 'nested (2 output selectors)',
+  kind: 'tick',
+  expected: oncePerTick,
   arity: 1,
   create: ({ createSelector }, count) => {
     // Wrapped rather than returned as-is. `entities => entities` is an identity
@@ -114,6 +146,8 @@ const nested = {
  */
 const threeInputsParametric = {
   name: '3 inputs, (state, props)',
+  kind: 'tick',
+  expected: oncePerChangedEntity,
   arity: 2,
   create: ({ createSelector }, count) =>
     createSelector(
@@ -128,6 +162,8 @@ const threeInputsParametric = {
 /** Six input selectors, parametric — enough that gathering them dominates. */
 const sixInputs = {
   name: '6 inputs, (state, props)',
+  kind: 'tick',
+  expected: oncePerChangedEntity,
   arity: 2,
   create: ({ createSelector }, count) =>
     createSelector(
@@ -146,6 +182,107 @@ const sixInputs = {
     )
 }
 
+/**
+ * Memoizers called directly, with no selector and no state production around
+ * them.
+ *
+ * `createSelector` calls its `argsMemoize` and its `memoize` once each per call,
+ * so a change inside one of them is at most a few nanoseconds of a call that
+ * costs 25 ns on the cheap shapes and several hundred on the parametric ones —
+ * under the harness's own noise floor either way. Measuring the memoized function
+ * on its own is the only way to put a number on that class of change.
+ *
+ * These are deliberately not proposals about what to optimise. A win here is only
+ * worth having if it survives into one of the shapes above.
+ */
+
+/** Hit path, one object argument: one WeakMap lookup and one terminated check. */
+const microWeakMapHitOneArg = {
+  name: 'micro: weakMapMemoize hit (1 arg)',
+  kind: 'micro',
+  // Every call passes the same argument, so exactly one call ever computes.
+  expected: () => 1,
+  create: ({ weakMapMemoize }, count) => {
+    const arg = { value: 1 }
+    const memoized = weakMapMemoize(input => {
+      count()
+      return input.value
+    })
+
+    return () => memoized(arg)
+  }
+}
+
+/**
+ * Hit path, two object arguments — the depth a `(state, props)` selector walks.
+ * One WeakMap lookup per argument, so this is where a per-argument change shows
+ * up at twice the size.
+ */
+const microWeakMapHitTwoArgs = {
+  name: 'micro: weakMapMemoize hit (2 args)',
+  kind: 'micro',
+  expected: () => 1,
+  create: ({ weakMapMemoize }, count) => {
+    const first = { value: 1 }
+    const second = { value: 2 }
+    const memoized = weakMapMemoize((a, b) => {
+      count()
+      return a.value + b.value
+    })
+
+    return () => memoized(first, second)
+  }
+}
+
+/** Hit path, `lruMemoize` at its default `maxSize` of 1: one equality compare. */
+const microLruHit = {
+  name: 'micro: lruMemoize hit (1 arg)',
+  kind: 'micro',
+  expected: () => 1,
+  create: ({ lruMemoize }, count) => {
+    const arg = { value: 1 }
+    const memoized = lruMemoize(input => {
+      count()
+      return input.value
+    })
+
+    return () => memoized(arg)
+  }
+}
+
+/**
+ * Miss path with eviction: twice as many distinct arguments as the cache holds,
+ * so every call misses, and every miss both inserts and evicts. This is the path
+ * that reallocates the entries array, and nothing else in this file reaches it
+ * often enough to price it.
+ *
+ * The rotating index costs an increment and a compare per call, paid identically
+ * by both variants.
+ */
+const microLruMissEvict = {
+  name: 'micro: lruMemoize miss+evict (maxSize 10)',
+  kind: 'micro',
+  // Nothing ever hits, so every call computes — the priming pass included.
+  expected: (ticks, config) =>
+    config.callsPerTick + ticks * config.callsPerTick,
+  create: ({ lruMemoize }, count) => {
+    const args = Array.from({ length: 20 }, (_, value) => ({ value }))
+    const memoized = lruMemoize(
+      input => {
+        count()
+        return input.value
+      },
+      { maxSize: 10 }
+    )
+    let index = 0
+
+    return () => {
+      index = index === 19 ? 0 : index + 1
+      return memoized(args[index])
+    }
+  }
+}
+
 const shapes = [
   oneInput,
   threeInputs,
@@ -153,33 +290,41 @@ const shapes = [
   sixInputs,
   parametric,
   parametricLruArgs,
-  nested
+  nested,
+  microWeakMapHitOneArg,
+  microWeakMapHitTwoArgs,
+  microLruHit,
+  microLruMissEvict
 ]
 
 /* Floors. Not proposals — no introspection, no configurable memoization, no
- * argument-level cache. They are the budget a rewrite has. */
+ * argument-level cache. They are the budget a rewrite has.
+ *
+ * They also serve as controls: they contain no `reselect` code at all, so a run
+ * where a floor moves has moved for reasons that have nothing to do with the
+ * change under test. */
 
 /** One reference compare, for the slice shape. */
-function createSliceFloor() {
-  let recomputations = 0
-  let lastEntities
-  let lastResult
+const sliceFloor = {
+  name: 'floor: slice (hand-written)',
+  kind: 'tick',
+  expected: oncePerTick,
+  arity: 1,
+  createRaw: count => {
+    let lastEntities
+    let lastResult
 
-  return {
-    name: 'floor: slice (hand-written)',
-    variant: '',
-    run: state => {
+    return state => {
       const entities = state.entities
 
       if (entities !== lastEntities) {
         lastEntities = entities
-        recomputations += 1
+        count()
         lastResult = entities[0]
       }
 
       return lastResult
-    },
-    recomputations: () => recomputations
+    }
   }
 }
 
@@ -189,14 +334,15 @@ function createSliceFloor() {
  * since consecutive calls carry different props, so it would miss every time and
  * recompute 200x more often — which is what the recomputation column caught.
  */
-function createParametricFloor() {
-  let recomputations = 0
-  const cache = new Map()
+const parametricFloor = {
+  name: 'floor: parametric (hand-written)',
+  kind: 'tick',
+  expected: oncePerChangedEntity,
+  arity: 2,
+  createRaw: count => {
+    const cache = new Map()
 
-  return {
-    name: 'floor: parametric (hand-written)',
-    variant: '',
-    run: (state, props) => {
+    return (state, props) => {
       const entity = state.entities[props.id]
 
       let record = cache.get(props.id)
@@ -208,56 +354,102 @@ function createParametricFloor() {
         return record.result
       }
 
-      recomputations += 1
+      count()
       record.entity = entity
       record.result = project(entity)
 
       return record.result
-    },
-    recomputations: () => recomputations
+    }
   }
 }
+
+/**
+ * A plain call through a closure, for the micro cases. Anything measured above
+ * this is what memoization costs; this is what it is compared against.
+ */
+const microFloor = {
+  name: 'floor: direct call (hand-written)',
+  kind: 'micro',
+  expected: (ticks, config) =>
+    config.callsPerTick + ticks * config.callsPerTick,
+  createRaw: count => {
+    const arg = { value: 1 }
+    const compute = input => {
+      count()
+      return input.value
+    }
+
+    return () => compute(arg)
+  }
+}
+
+const floors = [sliceFloor, parametricFloor, microFloor]
 
 const implementations = [
   { variant: 'base', module: base },
   { variant: 'current', module: current }
 ]
 
+const wrap = (shape, run, recomputations, variant) => ({
+  name: shape.name,
+  kind: shape.kind,
+  variant,
+  expected: shape.expected,
+  run,
+  recomputations
+})
+
 /**
- * One factory per (shape, implementation) pair, plus the floors. Shape-major, so
- * a pair sits on adjacent rows and is measured back to back within each round.
+ * One descriptor per (shape, implementation) pair, plus the floors. Shape-major,
+ * so a pair sits on adjacent rows and is measured back to back within each round.
+ *
+ * `instantiate()` builds a fresh selector and a fresh counter; the harness calls
+ * it once per round so no round inherits the previous round's cache.
  */
 export const cases = [
   ...shapes.flatMap(shape =>
-    implementations.map(({ variant, module }) => () => {
-      let recomputations = 0
-      const selector = shape.create(module, () => {
-        recomputations += 1
-      })
+    implementations.map(({ variant, module }) => ({
+      name: shape.name,
+      kind: shape.kind,
+      variant,
+      expected: shape.expected,
+      instantiate: () => {
+        let recomputations = 0
+        const selector = shape.create(module, () => {
+          recomputations += 1
+        })
 
-      return {
-        name: shape.name,
-        variant,
-        run:
-          shape.arity === 1
+        const run =
+          shape.kind === 'micro'
+            ? selector
+            : shape.arity === 1
             ? state => selector(state)
-            : (state, props) => selector(state, props),
-        recomputations: () => recomputations
-      }
-    })
-  ),
-  createSliceFloor,
-  createParametricFloor
-]
+            : (state, props) => selector(state, props)
 
-/**
- * Cases whose input is a single entity rather than a whole slice, so they
- * recompute once per *changed entity* per tick instead of once per tick.
- */
-export const perEntityCases = new Set([
-  threeInputsParametric.name,
-  sixInputs.name,
-  parametric.name,
-  parametricLruArgs.name,
-  'floor: parametric (hand-written)'
-])
+        return wrap(shape, run, () => recomputations, variant)
+      }
+    }))
+  ),
+  // The floors run as a base/current pair of the *same* hand-written function, so
+  // they go through the identical comparison machinery every other case does
+  // while being guaranteed to have no difference to find. Anything but "within
+  // noise" from a floor is the harness reporting a difference that cannot exist,
+  // which condemns every other number in that run.
+  ...floors.flatMap(shape =>
+    ['base', 'current'].map(variant => ({
+      name: shape.name,
+      kind: shape.kind,
+      variant,
+      isControl: true,
+      expected: shape.expected,
+      instantiate: () => {
+        let recomputations = 0
+        const run = shape.createRaw(() => {
+          recomputations += 1
+        })
+
+        return wrap(shape, run, () => recomputations, variant)
+      }
+    }))
+  )
+]

--- a/bench/profile.mjs
+++ b/bench/profile.mjs
@@ -1,7 +1,10 @@
 /**
  * Runs one case in isolation so `--cpu-prof` attributes samples to it alone.
  *
- * Usage: node --cpu-prof --cpu-prof-dir=bench/.build/prof bench/profile.mjs [name]
+ * Build without minification first, or every frame in the profile is a one-letter
+ * name:
+ *   node bench/build.mjs --no-minify
+ *   node --cpu-prof --cpu-prof-dir=bench/.build/prof bench/profile.mjs [name] [variant]
  */
 import { cases } from './cases.mjs'
 import {
@@ -14,25 +17,41 @@ import {
 const wanted = process.argv[2] ?? '1 input, (state, props)'
 const variant = process.argv[3] ?? 'base'
 
-const factory = cases.find(createCase => {
-  const instance = createCase()
-  return instance.name.trim() === wanted.trim() && instance.variant === variant
-})
+const descriptor = cases.find(
+  candidate =>
+    candidate.name.trim() === wanted.trim() && candidate.variant === variant
+)
 
-if (!factory) {
+if (!descriptor) {
   console.error(`no case named ${wanted} with variant ${variant}`)
+  console.error('\navailable:')
+  for (const candidate of cases) {
+    console.error(
+      `  ${candidate.name.trim()} [${candidate.variant || 'floor'}]`
+    )
+  }
   process.exit(1)
 }
 
+const TICKS = 2000
+
 const props = createProps()
-const instance = factory()
+const instance = descriptor.instantiate()
 let state = createInitialState()
 
-for (let tick = 0; tick < 2000; tick += 1) {
-  state = applyTick(state, tick)
+if (descriptor.kind === 'micro') {
+  for (let tick = 0; tick < TICKS; tick += 1) {
+    for (let call = 0; call < config.callsPerTick; call += 1) {
+      instance.run(state, props[call])
+    }
+  }
+} else {
+  for (let tick = 0; tick < TICKS; tick += 1) {
+    state = applyTick(state, tick)
 
-  for (let call = 0; call < config.callsPerTick; call += 1) {
-    instance.run(state, props[call])
+    for (let call = 0; call < config.callsPerTick; call += 1) {
+      instance.run(state, props[call])
+    }
   }
 }
 

--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -11,8 +11,19 @@
  *     processes credited a 10% swing to a commit that had not touched the code.
  *   - rounds interleaved across cases, so a machine that slows down partway
  *     through slows every case rather than one.
+ *   - each case's round scaled to a comparable wall time (see `calibrate`).
+ *     Measured noise tracked round *duration* and nothing else: at a fixed tick
+ *     count the cheap cases ran 25 ms rounds and reported +-4-9% on identical
+ *     code, while the parametric cases ran 500 ms rounds and reported +-1-2%.
+ *   - each pair measured in both orders, so whatever penalty second place
+ *     carries is not always paid by the same variant.
  *   - the minimum of many rounds, not the mean, gated against a measured noise
  *     floor (see `measureAll`).
+ *   - the whole measurement repeated in fresh processes (see `--repeat`). A
+ *     process can settle into a different JIT regime for one of the two bundles
+ *     and stay there: one real run reported a change at 1.62x, four times its
+ *     true size, and no statistic computed inside that process could tell,
+ *     because every round in it agreed. Only another process disagrees.
  *   - a fixed script of ticks, so recomputation counts are reproducible and a
  *     variant that silently skips work cannot read as a win.
  *
@@ -20,9 +31,15 @@
  * got round to freeing, and on a change that removed two allocations per call it
  * can go *up*. Allocation is paid in the time column instead, which is where a
  * caller feels it too.
+ *
+ * Usage:
+ *   node --expose-gc bench/run.mjs [--repeat=N] [--rounds=N] [--target-ms=N]
+ *                                  [--filter=<substring>]
  */
+import { spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
-import { cases, perEntityCases } from './cases.mjs'
+import { fileURLToPath } from 'node:url'
+import { cases } from './cases.mjs'
 import {
   applyTick,
   config,
@@ -34,20 +51,84 @@ const meta = JSON.parse(
   readFileSync(new URL('./.build/meta.json', import.meta.url), 'utf8')
 )
 
-// Enough ticks that the cheapest case still takes tens of milliseconds per
-// round. At 200 the slice cases landed at 1.9 ms with a 63% spread between
-// rounds, which cannot resolve the differences this harness exists to measure.
-const TICKS = 1000
-// Enough rounds that the minimum is a settled floor rather than the luckiest of
-// a handful. At 7 the per-round spread sat at 9-17%, which swallowed every
-// difference worth reporting.
-const ROUNDS = 15
-const WARMUP_ROUNDS = 2
+const flag = (name, fallback) => {
+  const found = process.argv.find(arg => arg.startsWith(`--${name}=`))
+  return found === undefined ? fallback : found.slice(name.length + 3)
+}
+const numericFlag = (name, fallback) => Number(flag(name, fallback))
 
-const CALLS_PER_ROUND = TICKS * config.callsPerTick
+/**
+ * Fresh processes, not more rounds in this one. Rounds inside a process share its
+ * JIT state, so they agree with each other whether or not they are right.
+ */
+const REPEAT = numericFlag('repeat', 3)
+/** Enough rounds that the minimum is a settled floor rather than the luckiest of a handful. */
+const ROUNDS = numericFlag('rounds', 10)
+const WARMUP_ROUNDS = 2
+/**
+ * Each round is scaled to land near this. Above roughly 200 ms a round absorbs a
+ * scheduler quantum (~15 ms on Windows) without much trace; at 25 ms it cannot,
+ * which is the whole reason the cheap cases used to be unmeasurable.
+ */
+const TARGET_ROUND_MS = numericFlag('target-ms', 300)
+const FILTER = flag('filter', '')
+/**
+ * Diagnostics. `--ticks=N` fixes the tick count for every case and skips
+ * calibration; `--alternate=0` runs every round in one order. Both exist because
+ * an A/A check — the same commit on both sides — is the only way to tell a
+ * harness bug from a result, and when one shows up these are how you find which
+ * part of the harness caused it.
+ */
+const FIXED_TICKS = Number(flag('ticks', 0))
+const ALTERNATE = flag('alternate', '1') !== '0'
+const DUMP_ROUNDS = process.argv.includes('--dump-rounds')
 
 /** A difference below this is reported as noise even if the spreads are tight. */
 const NOISE_FLOOR = 0.02
+/** Runs whose reported changes differ by more than this are not one measurement. */
+const RUN_DISAGREEMENT = 0.05
+
+const CALIBRATION_TICKS = 100
+const MIN_TICKS = 20
+const MAX_TICKS = 500_000
+
+/**
+ * Which cases get reported. Every case still *runs* every round — see
+ * `KEEPALIVE_TICKS`.
+ *
+ * The floors are always reported: they are the controls, and a run without them
+ * has nothing to compare its own noise against.
+ */
+const isSelected = descriptor =>
+  !FILTER || descriptor.isControl || descriptor.name.includes(FILTER)
+
+const selected = cases.filter(isSelected)
+
+/**
+ * Cases that are not being reported still run, at a token tick count, because
+ * the number of distinct cases sharing the timed loop changes what the timed loop
+ * costs.
+ *
+ * `runRound` calls `instance.run(state, props[call])`, and `run` is a different
+ * closure for every case. With a dozen of them that call site is megamorphic and
+ * no case gets inlined. Narrow the set to a single shape — two closures — and V8
+ * inlines one of them into the loop and leaves the other to a polymorphic stub.
+ * Filtering to one shape therefore reported the same commit as 1.40x faster than
+ * itself, consistently, with a 3% spread, on byte-identical bundles: whichever
+ * variant lost the inlining ran 40% slower. The full set reported the same pair
+ * at -0.9%.
+ *
+ * Twenty ticks is plenty. What matters is that the call site keeps seeing every
+ * case, not how long it spends in any of them.
+ *
+ * This makes a filtered run's *comparison* trustworthy, not its absolute ns/call.
+ * A filtered run still allocates far less overall, so the reported case runs
+ * against a quieter heap: `1 input, (state, props)` reads about 225 ns filtered
+ * and about 330 ns unfiltered. Both variants shift together, so the pair is still
+ * a fair comparison, but do not quote a filtered ns/call next to an unfiltered
+ * one.
+ */
+const KEEPALIVE_TICKS = 20
 
 function collectGarbage() {
   if (typeof globalThis.gc === 'function') {
@@ -61,8 +142,8 @@ function collectGarbage() {
 }
 
 /** One round: build a fresh case, replay the script, return time and recomputations. */
-function runRound(createCase, props) {
-  const instance = createCase()
+function runRound(descriptor, props, ticks) {
+  const instance = descriptor.instantiate()
   let state = createInitialState()
 
   // Prime the cache so the round measures steady state rather than N misses.
@@ -80,13 +161,24 @@ function runRound(createCase, props) {
   // whichever variant allocates more pay for its garbage off the clock. Timing
   // everything charges each variant for the collections it caused, and merely
   // dilutes differences rather than inventing them.
+  //
+  // The micro cases have no state to produce and allocate nothing per call, so
+  // neither half of that argument applies to them and their loop is bare.
   const startedAt = performance.now()
 
-  for (let tick = 0; tick < TICKS; tick += 1) {
-    state = applyTick(state, tick)
+  if (descriptor.kind === 'micro') {
+    for (let tick = 0; tick < ticks; tick += 1) {
+      for (let call = 0; call < config.callsPerTick; call += 1) {
+        instance.run(state, props[call])
+      }
+    }
+  } else {
+    for (let tick = 0; tick < ticks; tick += 1) {
+      state = applyTick(state, tick)
 
-    for (let call = 0; call < config.callsPerTick; call += 1) {
-      instance.run(state, props[call])
+      for (let call = 0; call < config.callsPerTick; call += 1) {
+        instance.run(state, props[call])
+      }
     }
   }
 
@@ -95,25 +187,132 @@ function runRound(createCase, props) {
   return { elapsed, recomputations: instance.recomputations() }
 }
 
-function measureAll(props) {
+const clamp = value => Math.min(MAX_TICKS, Math.max(MIN_TICKS, value))
+
+/**
+ * Picks a tick count per case so every round takes about `TARGET_ROUND_MS`.
+ *
+ * A single global tick count cannot work: the cases here span 25 ns to 700 ns per
+ * call, so the same count produces rounds 30x apart in duration, and the short
+ * ones are dominated by whatever else the machine did during them.
+ *
+ * Two stages, because a first estimate taken from a cold case is wrong by roughly
+ * the factor the optimising compiler is about to win: the pilot rounds run
+ * unoptimised, so scaling straight off them under-counts by 5-10x. The second
+ * stage re-scales from a round at the estimated count, by which point the case is
+ * warm.
+ *
+ * Calibrated per case *name*, and both variants of a shape get the baseline's
+ * count, so a pair always does identical work.
+ *
+ * Every case is calibrated, including the variants whose result is discarded.
+ * Calibrating only one of a pair is not a saving, it is a bias: the calibrated
+ * variant reaches the measured rounds having run five rounds the other has not,
+ * and it measured 30-40% SLOWER for it, with a half-percent spread, on bundles
+ * that were byte-identical. Whichever variant was listed first took the penalty,
+ * which is how it was caught. Doing the work for both sides costs a few seconds
+ * and removes the effect.
+ */
+function calibrate(props) {
+  const measured = new Map()
+
+  if (FIXED_TICKS > 0) {
+    return new Map(cases.map(({ name }) => [name, FIXED_TICKS]))
+  }
+
+  for (const descriptor of cases) {
+    if (!isSelected(descriptor)) {
+      measured.set(descriptor, KEEPALIVE_TICKS)
+      continue
+    }
+
+    let pilot = Infinity
+    // The first two are thrown away; they are what teaches the optimiser.
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const { elapsed } = runRound(descriptor, props, CALIBRATION_TICKS)
+      if (attempt >= 2) pilot = Math.min(pilot, elapsed)
+    }
+
+    const estimate = clamp(
+      Math.round(CALIBRATION_TICKS * (TARGET_ROUND_MS / Math.max(pilot, 0.01)))
+    )
+    const { elapsed } = runRound(descriptor, props, estimate)
+
+    measured.set(
+      descriptor,
+      clamp(Math.round(estimate * (TARGET_ROUND_MS / Math.max(elapsed, 0.01))))
+    )
+  }
+
+  // One count per name, taken from the baseline variant. Letting each variant use
+  // its own would hand a faster variant a shorter round and compare the two
+  // minima as though they had done the same work.
+  const ticksByName = new Map()
+
+  for (const descriptor of cases) {
+    if (descriptor.variant === 'current' && ticksByName.has(descriptor.name)) {
+      continue
+    }
+
+    ticksByName.set(descriptor.name, measured.get(descriptor))
+  }
+
+  return ticksByName
+}
+
+/**
+ * Round order. Cases are shape-major, so a shape's two variants sit on adjacent
+ * indices; every other round runs each such group backwards. Whatever the second
+ * position in a group costs — a colder cache, a collection triggered by the case
+ * before it — both variants then pay it half the time instead of one paying it
+ * always.
+ */
+function roundOrder(round) {
+  const groups = new Map()
+
+  for (let index = 0; index < cases.length; index += 1) {
+    const { name } = cases[index]
+    if (!groups.has(name)) groups.set(name, [])
+    groups.get(name).push(index)
+  }
+
+  return [...groups.values()].flatMap(indices =>
+    !ALTERNATE || round % 2 === 0 ? indices : [...indices].reverse()
+  )
+}
+
+const median = values => {
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = sorted.length >> 1
+  return sorted.length % 2 === 1
+    ? sorted[middle]
+    : (sorted[middle - 1] + sorted[middle]) / 2
+}
+
+function measureAll(props, ticksByName) {
   const samples = cases.map(() => [])
-  let recomputations = cases.map(() => 0)
+  const recomputations = cases.map(() => 0)
 
   for (let round = 0; round < WARMUP_ROUNDS + ROUNDS; round += 1) {
-    for (let i = 0; i < cases.length; i += 1) {
-      const { elapsed, recomputations: count } = runRound(cases[i], props)
+    for (const index of roundOrder(round)) {
+      const descriptor = cases[index]
+      const { elapsed, recomputations: count } = runRound(
+        descriptor,
+        props,
+        ticksByName.get(descriptor.name)
+      )
 
       if (round >= WARMUP_ROUNDS) {
-        samples[i].push(elapsed)
-        recomputations[i] = count
+        samples[index].push(elapsed)
+        recomputations[index] = count
       }
     }
   }
 
-  return cases.map((createCase, i) => {
-    const rounds = samples[i]
+  const results = cases.map((descriptor, index) => {
+    const rounds = samples[index]
+    const ticks = ticksByName.get(descriptor.name)
     const min = Math.min(...rounds)
-    const identity = createCase()
 
     // How reproducible is the minimum itself? The spread across all rounds is the
     // wrong gate for a min-of-N statistic — it is set by the slowest round, the
@@ -121,142 +320,342 @@ function measureAll(props) {
     // here, burying every difference worth reporting. Splitting the rounds into
     // two halves and taking the gap between their minima measures how much this
     // case's minimum moves for reasons unrelated to the code.
-    const halfA = rounds.filter((_, index) => index % 2 === 0)
-    const halfB = rounds.filter((_, index) => index % 2 === 1)
-    const minNoise = Math.abs(Math.min(...halfA) - Math.min(...halfB)) / min
+    const halfA = rounds.filter((_, position) => position % 2 === 0)
+    const halfB = rounds.filter((_, position) => position % 2 === 1)
+
+    if (DUMP_ROUNDS) {
+      console.error(
+        `${descriptor.name} [${descriptor.variant || 'floor'}] ` +
+          rounds.map(value => value.toFixed(1)).join(' ')
+      )
+    }
 
     return {
-      name: identity.name,
-      variant: identity.variant,
+      name: descriptor.name,
+      kind: descriptor.kind,
+      variant: descriptor.variant,
+      isControl: Boolean(descriptor.isControl),
+      ticks,
       minMs: min,
-      minNoise,
-      nsPerCall: (min * 1e6) / CALLS_PER_ROUND,
-      recomputations: recomputations[i]
+      medianMs: median(rounds),
+      minNoise: Math.abs(Math.min(...halfA) - Math.min(...halfB)) / min,
+      nsPerCall: (min * 1e6) / (ticks * config.callsPerTick),
+      recomputations: recomputations[index],
+      expected: descriptor.expected(ticks, config)
     }
   })
+
+  return results.filter((_, index) => isSelected(cases[index]))
 }
 
 const pad = (value, width) => String(value).padStart(width)
 const padRight = (value, width) => String(value).padEnd(width)
+const percent = (value, width = 6) => pad((value * 100).toFixed(1) + '%', width)
 
-function formatDelta(current, baseline) {
-  const change = (current.minMs - baseline.minMs) / baseline.minMs
-  // Both minima wobble, so the difference has to clear both wobbles combined.
-  const threshold = Math.max(current.minNoise + baseline.minNoise, NOISE_FLOOR)
+const pairOf = (results, result) =>
+  result.variant === 'current'
+    ? results.find(
+        other => other.name === result.name && other.variant === 'base'
+      )
+    : undefined
 
-  if (Math.abs(change) <= threshold) {
-    return `${pad((change * 100).toFixed(1) + '%', 7)}  within noise (+-${(
-      threshold * 100
-    ).toFixed(1)}%)`
-  }
+/* ---------------------------------------------------------------- child mode */
 
-  const faster = change < 0
-  const ratio = faster
-    ? baseline.minMs / current.minMs
-    : current.minMs / baseline.minMs
-
-  return (
-    `${pad((change * 100).toFixed(1) + '%', 7)}  ` +
-    `${ratio.toFixed(2)}x ${faster ? 'faster' : 'SLOWER'}`
-  )
-}
-
-function main() {
+function measureOnce() {
   const exposedGc = collectGarbage()
   const props = createProps()
 
-  console.log(
-    `\nbaseline: ${meta.baselineRef} (${meta.baselineSha})   ` +
-      `NODE_ENV: ${meta.nodeEnv}` +
-      (meta.nodeEnv === 'production'
-        ? ''
-        : '   <- dev-mode checks are in the hot path')
-  )
-
-  console.log(
-    `\ncreateSelector hot path — ${config.callsPerTick.toLocaleString(
-      'en-US'
-    )} calls x ` +
-      `${TICKS} ticks = ${CALLS_PER_ROUND.toLocaleString(
-        'en-US'
-      )} calls per round, ` +
-      `${config.changedPerTick} of ${config.entities} entities change per tick, ` +
-      `min of ${ROUNDS} interleaved rounds`
-  )
-
   if (!exposedGc) {
-    console.log(
+    console.error(
       'WARNING: run with --expose-gc, rounds start from an uncontrolled heap'
     )
   }
 
-  const results = measureAll(props)
-
-  console.log('')
-  console.log(
-    `${padRight('case', 32)} ${padRight('variant', 8)} ${pad('min ms', 8)} ` +
-      `${pad('ns/call', 8)} ${pad('min +-', 7)} ${pad(
-        'recomputes',
-        11
-      )}   change`
-  )
-
-  for (const result of results) {
-    const baseline =
-      result.variant === 'current'
-        ? results.find(
-            other => other.name === result.name && other.variant === 'base'
-          )
-        : undefined
-
-    console.log(
-      `${padRight(result.name, 32)} ${padRight(result.variant, 8)} ` +
-        `${pad(result.minMs.toFixed(1), 8)} ${pad(
-          result.nsPerCall.toFixed(1),
-          8
-        )} ` +
-        `${pad((result.minNoise * 100).toFixed(1) + '%', 7)} ` +
-        `${pad(result.recomputations.toLocaleString('en-US'), 11)}   ` +
-        (baseline ? formatDelta(result, baseline) : '')
+  if (FILTER) {
+    console.error(
+      `filter ${JSON.stringify(FILTER)}: reporting ${selected.length} of ` +
+        `${cases.length} cases; the rest still run at ${KEEPALIVE_TICKS} ticks`
     )
   }
 
-  // Both figures include the priming pass, which runs before the timed region:
-  // a slice case recomputes once there, a per-entity case once per entity.
-  const perTick = 1 + TICKS
-  const perEntity = config.callsPerTick + TICKS * config.changedPerTick
+  const ticksByName = calibrate(props)
+  const results = measureAll(props, ticksByName)
 
-  const unexpected = results.filter(
-    result =>
-      result.recomputations !==
-      (perEntityCases.has(result.name) ? perEntity : perTick)
+  console.error('')
+  console.error(
+    `${padRight('case', 40)} ${padRight('variant', 8)} ${pad('ticks', 7)} ` +
+      `${pad('min ms', 8)} ${pad('ns/call', 8)} ${pad('min +-', 7)}   change`
   )
 
-  if (unexpected.length === 0) {
+  for (const result of results) {
+    const baseline = pairOf(results, result)
+    const change = baseline
+      ? (result.minMs - baseline.minMs) / baseline.minMs
+      : undefined
+
+    console.error(
+      `${padRight(result.name, 40)} ${padRight(result.variant, 8)} ` +
+        `${pad(result.ticks, 7)} ${pad(result.minMs.toFixed(1), 8)} ` +
+        `${pad(result.nsPerCall.toFixed(1), 8)} ${percent(
+          result.minNoise,
+          7
+        )}   ` +
+        (change === undefined ? '' : percent(change)) +
+        (result.recomputations === result.expected
+          ? ''
+          : `  RECOMPUTES ${result.recomputations.toLocaleString('en-US')}` +
+            ` != ${result.expected.toLocaleString('en-US')}`)
+    )
+  }
+
+  process.stdout.write(`\n__BENCH_JSON__${JSON.stringify(results)}\n`)
+}
+
+/* --------------------------------------------------------------- parent mode */
+
+function spawnChildren() {
+  const self = fileURLToPath(import.meta.url)
+  const passthrough = process.argv
+    .slice(2)
+    .filter(arg => !arg.startsWith('--repeat='))
+  const runs = []
+
+  for (let index = 0; index < REPEAT; index += 1) {
+    console.log(`\n=== run ${index + 1} of ${REPEAT} ===`)
+
+    const child = spawnSync(
+      process.execPath,
+      [...process.execArgv, self, '--child', ...passthrough],
+      { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] }
+    )
+
+    if (child.status !== 0) {
+      console.error(`run ${index + 1} exited with status ${child.status}`)
+      process.exitCode = 1
+      return runs
+    }
+
+    const marker = child.stdout.indexOf('__BENCH_JSON__')
+
+    if (marker === -1) {
+      console.error(`run ${index + 1} produced no results`)
+      process.exitCode = 1
+      return runs
+    }
+
+    runs.push(JSON.parse(child.stdout.slice(marker + '__BENCH_JSON__'.length)))
+  }
+
+  return runs
+}
+
+/**
+ * A change is a result only if every run agrees on its direction and every run
+ * puts it clear of that run's own noise floor. That is the rule the three-run
+ * manual procedure applied by hand, and it is the only thing that caught the run
+ * whose JIT regime differed: within that run the change was consistent across all
+ * rounds and four times its true size.
+ */
+function verdict(changes, thresholds) {
+  const significant = changes.map(
+    (change, index) => Math.abs(change) > thresholds[index]
+  )
+  const positive = changes.filter(change => change > 0).length
+  const sameSign = positive === 0 || positive === changes.length
+  const spread = Math.max(...changes) - Math.min(...changes)
+
+  if (!sameSign) return 'no result (runs disagree on direction)'
+  if (!significant.every(Boolean)) {
+    return significant.some(Boolean)
+      ? 'unconfirmed (not clear of noise in every run)'
+      : 'within noise'
+  }
+
+  const mean =
+    changes.reduce((total, change) => total + change, 0) / changes.length
+  const faster = mean < 0
+  const ratio = faster ? 1 / (1 + mean) : 1 + mean
+
+  return (
+    `${ratio.toFixed(2)}x ${faster ? 'faster' : 'SLOWER'}` +
+    (spread > RUN_DISAGREEMENT
+      ? `  (runs spread ${(spread * 100).toFixed(
+          1
+        )} points — treat as approximate)`
+      : '')
+  )
+}
+
+function report(runs) {
+  const [first] = runs
+
+  console.log(
+    `\nbaseline: ${meta.baselineRef} (${meta.baselineSha})   ` +
+      `NODE_ENV: ${meta.nodeEnv}   ` +
+      `${meta.minified ? 'minified' : 'not minified'}` +
+      (meta.nodeEnv === 'production'
+        ? ''
+        : '   <- dev-mode checks are in the hot path')
+  )
+  console.log(
+    `${config.callsPerTick.toLocaleString('en-US')} calls per tick, ` +
+      `${config.changedPerTick} of ${config.entities} entities change per tick, ` +
+      `ticks per case calibrated to ~${TARGET_ROUND_MS} ms per round, ` +
+      `min of ${ROUNDS} rounds, ${runs.length} independent runs`
+  )
+
+  console.log('')
+  console.log(
+    `${padRight('case', 40)} ${pad('base ns', 8)} ${pad('curr ns', 8)}   ` +
+      `${padRight('per-run change', 8 * runs.length)}  verdict`
+  )
+
+  for (const result of first) {
+    if (result.variant !== 'current' || result.isControl) continue
+
+    const changes = []
+    const thresholds = []
+
+    for (const run of runs) {
+      const currentResult = run.find(
+        other => other.name === result.name && other.variant === 'current'
+      )
+      const baseResult = run.find(
+        other => other.name === result.name && other.variant === 'base'
+      )
+
+      changes.push((currentResult.minMs - baseResult.minMs) / baseResult.minMs)
+      thresholds.push(
+        Math.max(currentResult.minNoise + baseResult.minNoise, NOISE_FLOOR)
+      )
+    }
+
+    const baseline = pairOf(first, result)
+
     console.log(
-      `\nRecomputations are as expected everywhere: ${perTick.toLocaleString(
-        'en-US'
-      )} ` +
-        `for a case whose input is a whole slice, ${perEntity.toLocaleString(
-          'en-US'
-        )} ` +
-        `for a case whose input is one entity. Same work, so the times compare.`
+      `${padRight(result.name, 40)} ${pad(baseline.nsPerCall.toFixed(1), 8)} ` +
+        `${pad(result.nsPerCall.toFixed(1), 8)}   ` +
+        `${padRight(
+          changes.map(change => percent(change, 7)).join(''),
+          8 * runs.length
+        )}  ` +
+        verdict(changes, thresholds)
+    )
+  }
+
+  reportControls(runs)
+  reportRecomputations(runs)
+}
+
+/**
+ * The floors contain no `reselect` code, so nothing under test can move them. How
+ * much they moved between runs is therefore this machine's contribution, measured
+ * rather than assumed, and it is the number to compare any claim above against.
+ */
+function reportControls(runs) {
+  const floors = runs[0].filter(
+    result => result.isControl && result.variant === 'current'
+  )
+
+  const measured = floors.map(floor => {
+    const changes = runs.map(run => {
+      const current = run.find(
+        other => other.name === floor.name && other.variant === 'current'
+      )
+      const base = run.find(
+        other => other.name === floor.name && other.variant === 'base'
+      )
+      return (current.minMs - base.minMs) / base.minMs
+    })
+
+    const drift = runs.map(
+      run =>
+        run.find(other => other.name === floor.name && other.variant === 'base')
+          .nsPerCall
+    )
+
+    return {
+      name: floor.name,
+      changes,
+      worst: Math.max(...changes.map(Math.abs)),
+      drift: (Math.max(...drift) - Math.min(...drift)) / Math.min(...drift)
+    }
+  })
+
+  const falsePositives = measured.filter(entry => entry.worst > NOISE_FLOOR)
+  const worst = Math.max(...measured.map(entry => entry.worst))
+  const worstDrift = Math.max(...measured.map(entry => entry.drift))
+
+  console.log(
+    '\nControls (the same hand-written function compared against itself, ' +
+      'so every one of these is zero in principle):'
+  )
+
+  for (const entry of measured) {
+    console.log(
+      `  ${padRight(entry.name, 40)} ` +
+        entry.changes.map(change => percent(change)).join(' ')
+    )
+  }
+
+  console.log(
+    `  Worst control reading ${(worst * 100).toFixed(1)}%. ` +
+      'A paired claim near or below that size is the harness, not the code.'
+  )
+
+  console.log(
+    `  Between-run drift of the same control was ${(worstDrift * 100).toFixed(
+      1
+    )}%, which is what pairing inside one run exists to cancel.`
+  )
+
+  if (falsePositives.length > 0) {
+    console.log(
+      `  WARNING: ${falsePositives.length} control(s) read above the ` +
+        `${(NOISE_FLOOR * 100).toFixed(
+          0
+        )}% floor. This run found a difference ` +
+        'between identical code, so treat every result above as unproven.'
+    )
+  }
+}
+
+/**
+ * Recomputation counts, checked per case against what its script must produce.
+ * Same work, or the times do not compare — a variant that skipped a recomputation
+ * would otherwise read as the fastest thing here.
+ */
+function reportRecomputations(runs) {
+  const wrong = runs.flatMap((run, index) =>
+    run
+      .filter(result => result.recomputations !== result.expected)
+      .map(result => ({ run: index + 1, ...result }))
+  )
+
+  if (wrong.length === 0) {
+    console.log(
+      '\nRecomputations are as expected for every case in every run, ' +
+        'so the times compare.'
     )
     return
   }
 
   console.log('')
-  for (const result of unexpected) {
-    const expected = perEntityCases.has(result.name) ? perEntity : perTick
+  for (const result of wrong) {
     console.log(
-      `WARNING: ${result.name.trim()} (${
+      `WARNING: run ${result.run}, ${result.name.trim()} (${
         result.variant || 'floor'
-      }) recomputed ` +
-        `${result.recomputations.toLocaleString('en-US')} times, expected ` +
-        `${expected.toLocaleString('en-US')} — its time is not comparable`
+      }) recomputed ${result.recomputations.toLocaleString('en-US')} times, ` +
+        `expected ${result.expected.toLocaleString('en-US')} — ` +
+        `its time is not comparable`
     )
   }
   process.exitCode = 1
 }
 
-main()
+if (process.argv.includes('--child')) {
+  measureOnce()
+} else {
+  const runs = spawnChildren()
+  if (runs.length === REPEAT) report(runs)
+}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react-dom": "^18.2.0",
     "react-redux": "^9.0.4",
     "rimraf": "^3.0.2",
+    "rolldown": "1.2.4",
     "shelljs": "^0.8.5",
     "tsup": "^8.2.4",
     "typescript": "^5.8.2",

--- a/test/benchmarks/orderOfExecution.bench.ts
+++ b/test/benchmarks/orderOfExecution.bench.ts
@@ -43,8 +43,7 @@ describe('Less vs more computation in input selectors', () => {
     return state.todos.filter(todo => todo.completed)
   })
   const commonOptions: Options = {
-    iterations: 10,
-    time: 0
+    time: 500
   }
   setFunctionNames({ selectorLessInInput, selectorMoreInInput, nonMemoized })
   const createOptions = <S extends OutputSelector>(

--- a/test/benchmarks/reselect.bench.ts
+++ b/test/benchmarks/reselect.bench.ts
@@ -9,9 +9,11 @@ import type { RootState } from '../testUtils'
 import { setFunctionNames, setupStore } from '../testUtils'
 
 describe('Memoize methods comparison', () => {
+  // Sample for half a second rather than taking a fixed ten iterations. Ten
+  // iterations of a call this cheap reported +-60% error and ranked cases in
+  // impossible orders; see the note in 'Cached vs non-cached length in for loops'.
   const commonOptions: Options = {
-    iterations: 10,
-    time: 0
+    time: 500
   }
   const store = setupStore()
   const state = store.getState()
@@ -119,9 +121,12 @@ describe('Memoize methods comparison', () => {
 })
 
 describe('Cached vs non-cached length in for loops', () => {
+  // This block is why the fixed ten-iteration options went away. At `iterations:
+  // 10, time: 0` it reported 'length cached' as slower than 'length not cached',
+  // across every run, which cannot happen. Ten samples of a sub-microsecond loop
+  // measure the sampler.
   const commonOptions: Options = {
-    iterations: 10,
-    time: 0
+    time: 500
   }
   const store = setupStore()
   const state = store.getState()
@@ -157,148 +162,5 @@ describe('Cached vs non-cached length in for loops', () => {
       }
     },
     commonOptions
-  )
-})
-
-describe.todo('nested field access', () => {
-  const commonOptions: Options = {
-    iterations: 10,
-    time: 0
-  }
-  const store = setupStore()
-  const state = store.getState()
-  const selectorDefault = createSelector(
-    (state: RootState) => state.users,
-    users => users.user.details.preferences.notifications.push.frequency
-  )
-  const selectorDefault1 = createSelector(
-    (state: RootState) => state.users.user,
-    user => user.details.preferences.notifications.push.frequency
-  )
-  const nonMemoizedSelector = (state: RootState) =>
-    state.users.user.details.preferences.notifications.push.frequency
-  bench(
-    'selectorDefault',
-    () => {
-      selectorDefault(state)
-    },
-    commonOptions
-  )
-  bench(
-    'nonMemoizedSelector',
-    () => {
-      nonMemoizedSelector(state)
-    },
-    commonOptions
-  )
-  bench(
-    'selectorDefault1',
-    () => {
-      selectorDefault1(state)
-    },
-    commonOptions
-  )
-})
-
-describe.todo('simple field access', () => {
-  const commonOptions: Options = {
-    iterations: 10,
-    time: 0
-  }
-  const store = setupStore()
-  const state = store.getState()
-  const selectorDefault = createSelector(
-    (state: RootState) => state.users,
-    users => users.user.details.preferences.notifications.push.frequency
-  )
-  const selectorDefault1 = createSelector(
-    (state: RootState) => state.users.user,
-    user => user.details.preferences.notifications.push.frequency
-  )
-  const selectorDefault2 = createSelector(
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    (state: RootState) => state.users,
-    users => users.user.details.preferences.notifications.push.frequency
-  )
-  const nonMemoizedSelector = (state: RootState) =>
-    state.users.user.details.preferences.notifications.push.frequency
-  bench(
-    'selectorDefault',
-    () => {
-      selectorDefault(state)
-    },
-    commonOptions
-  )
-  bench(
-    'nonMemoizedSelector',
-    () => {
-      nonMemoizedSelector(state)
-    },
-    commonOptions
-  )
-  bench(
-    'selectorDefault1',
-    () => {
-      selectorDefault1(state)
-    },
-    commonOptions
-  )
-  bench(
-    'selectorDefault2',
-    () => {
-      selectorDefault2(state)
-    },
-    commonOptions
-  )
-})
-
-describe.todo('field accessors', () => {
-  const commonOptions: Options = {
-    iterations: 10,
-    time: 0
-  }
-  const store = setupStore()
-  const selectorDefault = createSelector(
-    [(state: RootState) => state.users],
-    users => users.appSettings
-  )
-  const nonMemoizedSelector = (state: RootState) => state.users.appSettings
-  setFunctionNames({ selectorDefault, nonMemoizedSelector })
-  bench(
-    selectorDefault,
-    () => {
-      selectorDefault(store.getState())
-    },
-    { ...commonOptions }
-  )
-  bench(
-    nonMemoizedSelector,
-    () => {
-      nonMemoizedSelector(store.getState())
-    },
-    { ...commonOptions }
   )
 })

--- a/test/benchmarks/weakMapMemoize.bench.ts
+++ b/test/benchmarks/weakMapMemoize.bench.ts
@@ -21,8 +21,7 @@ describe('Parametric selectors: weakMapMemoize vs others', () => {
   const state = store.getState()
   const arrayOfNumbers = Array.from({ length: 30 }, (num, index) => index)
   const commonOptions: Options = {
-    iterations: 10,
-    time: 0
+    time: 500
   }
   const runSelector = <S extends Selector>(selector: S) => {
     arrayOfNumbers.forEach(num => {
@@ -400,97 +399,5 @@ describe('Simple selectors: weakMapMemoize vs others', () => {
       selectTodoIdsAutotrack(store.getState())
     },
     createOptions(selectTodoIdsAutotrack)
-  )
-})
-
-describe.skip('weakMapMemoize memory leak', () => {
-  const store = setupStore()
-  const state = store.getState()
-  const arrayOfNumbers = Array.from(
-    { length: 2_000_000 },
-    (num, index) => index
-  )
-  const commonOptions: Options = {
-    warmupIterations: 0,
-    warmupTime: 0,
-    iterations: 1,
-    time: 0
-  }
-  const runSelector = <S extends Selector>(selector: S) => {
-    arrayOfNumbers.forEach(num => {
-      selector(state, num)
-    })
-    arrayOfNumbers.forEach(num => {
-      selector(state, num)
-    })
-  }
-  const selectorDefault = createSelector(
-    [(state: RootState) => state.todos, (state: RootState, id: number) => id],
-    todos => todos.map(({ id }) => id)
-  )
-  const selectorWeakMap = createSelector(
-    [(state: RootState) => state.todos, (state: RootState, id: number) => id],
-    todos => todos.map(({ id }) => id),
-    { memoize: weakMapMemoize }
-  )
-  const selectorArgsWeakMap = createSelector(
-    [(state: RootState) => state.todos, (state: RootState, id: number) => id],
-    todos => todos.map(({ id }) => id),
-    { argsMemoize: weakMapMemoize }
-  )
-  const selectorBothWeakMap = createSelector(
-    [(state: RootState) => state.todos, (state: RootState, id: number) => id],
-    todos => todos.map(({ id }) => id),
-    { argsMemoize: weakMapMemoize, memoize: weakMapMemoize }
-  )
-  setFunctionNames({
-    selectorDefault,
-    selectorWeakMap,
-    selectorArgsWeakMap,
-    selectorBothWeakMap
-  })
-  const createOptions = <S extends OutputSelector>(
-    selector: S,
-    commonOptions: Options = {}
-  ) => {
-    const options: Options = {
-      setup: (task, mode) => {
-        if (mode === 'warmup') return
-        task.opts = {
-          afterAll: () => {
-            logSelectorRecomputations(selector)
-          }
-        }
-      }
-    }
-    return { ...commonOptions, ...options }
-  }
-  bench(
-    selectorDefault,
-    () => {
-      runSelector(selectorDefault)
-    },
-    createOptions(selectorDefault, commonOptions)
-  )
-  bench(
-    selectorWeakMap,
-    () => {
-      runSelector(selectorWeakMap)
-    },
-    createOptions(selectorWeakMap, commonOptions)
-  )
-  bench.skip(
-    selectorArgsWeakMap,
-    () => {
-      runSelector(selectorArgsWeakMap)
-    },
-    createOptions(selectorArgsWeakMap, commonOptions)
-  )
-  bench.skip(
-    selectorBothWeakMap,
-    () => {
-      runSelector(selectorBothWeakMap)
-    },
-    createOptions(selectorBothWeakMap, commonOptions)
   )
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,6 +460,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.144.0":
+  version: 0.144.0
+  resolution: "@oxc-project/types@npm:0.144.0"
+  checksum: 10/e440aa06572a3dedc1c9f4f25cae2a6132761deb2ead8d0c5f139a51c343db054c2b4f0c26cc1b1f3e857b2add2821c5b268ea4321291b30a6589bb33201d5f8
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -484,6 +491,111 @@ __metadata:
     react-redux:
       optional: true
   checksum: 10/62ad00b875115eb2fb5b776665d2dbe71b1ad98f4342f409c67dfb27bd0cd7a13dffd7343bee6f232d0498429361f95541993bb2ecd747ad09a55069bc43303e
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.4"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.4"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.4"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.4"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.4"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10/4e95cf9ce23d75e5aa03ea0249cd86f7d1e21f83fbf6f8520e4edd8a251ba1b82c4ba9bc13cd24b6c4661daec6225b06e6d35c64c604e731b230b2a49af47d05
   languageName: node
   linkType: hard
 
@@ -4216,6 +4328,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-redux: "npm:^9.0.4"
     rimraf: "npm:^3.0.2"
+    rolldown: "npm:1.2.4"
     shelljs: "npm:^0.8.5"
     tsup: "npm:^8.2.4"
     typescript: "npm:^5.8.2"
@@ -4322,6 +4435,61 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 10/f3b8ce81eecbde4628b07bdf9e2fa8b684e0caea4999acb1e3b0402c695cd41f28cd075609a808e61ce2672f528ca079f675ab1d8e8d5f86d56643a03e0b8d2e
+  languageName: node
+  linkType: hard
+
+"rolldown@npm:1.2.4":
+  version: 1.2.4
+  resolution: "rolldown@npm:1.2.4"
+  dependencies:
+    "@oxc-project/types": "npm:=0.144.0"
+    "@rolldown/binding-android-arm64": "npm:1.2.4"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.4"
+    "@rolldown/binding-darwin-x64": "npm:1.2.4"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.4"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.4"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.4"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.4"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.4"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.4"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.4"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.4"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.4"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.4"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.4"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10/89447addc6695e0fe1224592ac7648545faf2077c18361b48df01d1f453a0a9b3390cedad58daccaf5dce7b37646cb5fb7e318c42b8b85d4998b33be43d05b43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:

- Rebuilds the just-added perf harness and benchmarking system
  - use Rolldown instead of ESBuild
  - some tweaks to ensure proper v8 optimizations when iterating test cases
  - updates to ensure a/b case flipping for fairer numbers
  - generally now nails the noise down to <2%