### PR TITLE
Optimize lruMemoize cache lookups

### DIFF
--- a/bench/cases.mjs
+++ b/bench/cases.mjs
@@ -283,6 +283,172 @@ const microLruMissEvict = {
   }
 }
 
+/**
+ * Hit path, three arguments. `lruMemoize` compares the argument lists element by
+ * element, so per-argument work in the comparator shows up here at three times
+ * the size it does in the one-argument case. A change that moves this case but
+ * not `micro: lruMemoize hit (1 arg)` is per-argument; one that moves both by the
+ * same amount is per-call.
+ */
+const microLruHitThreeArgs = {
+  name: 'micro: lruMemoize hit (3 args)',
+  kind: 'micro',
+  expected: () => 1,
+  create: ({ lruMemoize }, count) => {
+    const first = { value: 1 }
+    const second = { value: 2 }
+    const third = { value: 3 }
+    const memoized = lruMemoize((a, b, c) => {
+      count()
+      return a.value + b.value + c.value
+    })
+
+    return () => memoized(first, second, third)
+  }
+}
+
+/**
+ * Miss path with `resultEqualityCheck`, at the default `maxSize` of 1.
+ *
+ * `resultEqualityCheck` is the only thing that reads the cache's entries, and it
+ * reads them once per miss. The result function is deliberately trivial so the
+ * measurement is the bookkeeping rather than the payload — the realistic version
+ * below covers the other half of the question.
+ *
+ * Every call passes a fresh argument, so the argument cache never hits, and the
+ * result is always the same primitive, so `resultEqualityCheck` always matches
+ * and the dedupe branch is always taken.
+ */
+const microLruResultEqualitySingleton = {
+  name: 'micro: lruMemoize miss + resultEqualityCheck',
+  kind: 'micro',
+  // The argument cache never hits, so `func` runs on every call, priming
+  // included. `resultsCount` is deduped back down but `count()` is not.
+  expected: (ticks, config) =>
+    config.callsPerTick + ticks * config.callsPerTick,
+  create: ({ lruMemoize }, count) => {
+    const args = Array.from({ length: 20 }, (_, value) => ({ value }))
+    const memoized = lruMemoize(
+      () => {
+        count()
+        return 1
+      },
+      { resultEqualityCheck: (previous, next) => previous === next }
+    )
+    let index = 0
+
+    return () => {
+      index = index === 19 ? 0 : index + 1
+      return memoized(args[index])
+    }
+  }
+}
+
+/**
+ * The same path at `maxSize: 10`, which uses the LRU cache rather than the
+ * singleton one. The two caches reach the entries differently, so a change to
+ * that code can help one and not the other.
+ */
+const microLruResultEqualityLru = {
+  name: '  same, maxSize 10',
+  kind: 'micro',
+  expected: (ticks, config) =>
+    config.callsPerTick + ticks * config.callsPerTick,
+  create: ({ lruMemoize }, count) => {
+    const args = Array.from({ length: 20 }, (_, value) => ({ value }))
+    const memoized = lruMemoize(
+      () => {
+        count()
+        return 1
+      },
+      {
+        maxSize: 10,
+        resultEqualityCheck: (previous, next) => previous === next
+      }
+    )
+    let index = 0
+
+    return () => {
+      index = index === 19 ? 0 : index + 1
+      return memoized(args[index])
+    }
+  }
+}
+
+/**
+ * The realistic shape `resultEqualityCheck` exists for: a result function that
+ * rebuilds an array of ids, and a shallow compare that recognises the rebuild as
+ * unchanged. The payload dominates here, which is the point — it is the control
+ * on the two cases above, which deliberately have no payload at all. A change
+ * that moves those but not this one is real and does not matter.
+ */
+const microLruResultEqualityRealistic = {
+  name: '  same, array payload',
+  kind: 'micro',
+  expected: (ticks, config) =>
+    config.callsPerTick + ticks * config.callsPerTick,
+  create: ({ lruMemoize }, count) => {
+    const args = Array.from({ length: 20 }, (_, value) => ({ value }))
+    const todos = Array.from({ length: 20 }, (_, id) => ({ id }))
+    const memoized = lruMemoize(
+      () => {
+        count()
+        return todos.map(todo => todo.id)
+      },
+      {
+        resultEqualityCheck: (previous, next) => {
+          if (previous.length !== next.length) return false
+          for (let i = 0; i < previous.length; i += 1) {
+            if (previous[i] !== next[i]) return false
+          }
+          return true
+        }
+      }
+    )
+    let index = 0
+
+    return () => {
+      index = index === 19 ? 0 : index + 1
+      return memoized(args[index])
+    }
+  }
+}
+
+/**
+ * `weakMapMemoize` filling its cache rather than reading it. Every call passes a
+ * freshly allocated argument, so every call walks the node tree, allocates a
+ * cache node and writes it into a `WeakMap`.
+ *
+ * The cache is cleared once every `callsPerTick` calls. Without that it would
+ * grow without bound across a round — `weakMapMemoize` evicts nothing by default
+ * — and a case whose retained set grows for the length of the round measures the
+ * collector more than it measures the fill. Clearing costs one assignment,
+ * amortised over a thousand calls, and both variants pay it identically.
+ */
+const microWeakMapFill = {
+  name: 'micro: weakMapMemoize miss+fill',
+  kind: 'micro',
+  expected: (ticks, config) =>
+    config.callsPerTick + ticks * config.callsPerTick,
+  create: ({ weakMapMemoize }, count) => {
+    const memoized = weakMapMemoize(input => {
+      count()
+      return input.value
+    })
+    let sinceClear = 0
+
+    return () => {
+      if (sinceClear === 1000) {
+        memoized.clearCache()
+        sinceClear = 0
+      }
+      sinceClear += 1
+
+      return memoized({ value: sinceClear })
+    }
+  }
+}
+
 const shapes = [
   oneInput,
   threeInputs,
@@ -293,8 +459,13 @@ const shapes = [
   nested,
   microWeakMapHitOneArg,
   microWeakMapHitTwoArgs,
+  microWeakMapFill,
   microLruHit,
-  microLruMissEvict
+  microLruHitThreeArgs,
+  microLruMissEvict,
+  microLruResultEqualitySingleton,
+  microLruResultEqualityLru,
+  microLruResultEqualityRealistic
 ]
 
 /* Floors. Not proposals — no introspection, no configurable memoization, no

--- a/src/lruMemoize.ts
+++ b/src/lruMemoize.ts
@@ -19,7 +19,26 @@ interface Entry {
 interface Cache {
   get(key: unknown): unknown | NOT_FOUND_TYPE
   put(key: unknown, value: unknown): void
-  getEntries(): Entry[]
+  /**
+   * Returns the first cached entry whose value `resultEqualityCheck` accepts, or
+   * `undefined`.
+   *
+   * Searching inside the cache rather than handing out an array of entries is
+   * what lets the caller drop its `entries.find(entry => ...)` callback, and
+   * that callback was expensive in a way that does not look like it from the
+   * source. It captured `value`, a local of `memoized`, so V8 had to allocate
+   * that local in a heap context rather than a register — on every call,
+   * including the cache hits that never reach this code at all. Removing it
+   * measured 1.12x on the hit path. Keep this signature callback-free.
+   *
+   * Searching in place also avoids the one-element array the singleton cache
+   * used to build per miss, which is worth a further ~10% on the miss path when
+   * `resultEqualityCheck` is set.
+   */
+  findMatchingEntry(
+    value: unknown,
+    resultEqualityCheck: EqualityFn
+  ): Entry | undefined
   clear(): void
 }
 
@@ -38,8 +57,12 @@ function createSingletonCache(equals: EqualityFn): Cache {
       entry = { key, value }
     },
 
-    getEntries() {
-      return entry ? [entry] : []
+    findMatchingEntry(value: unknown, resultEqualityCheck: EqualityFn) {
+      const current = entry
+
+      return current !== undefined && resultEqualityCheck(current.value, value)
+        ? current
+        : undefined
     },
 
     clear() {
@@ -81,15 +104,29 @@ function createLruCache(maxSize: number, equals: EqualityFn): Cache {
     }
   }
 
-  function getEntries() {
-    return entries
+  function findMatchingEntry(value: unknown, resultEqualityCheck: EqualityFn) {
+    // Read the array once up front, the way `Array.prototype.find` would, so a
+    // `resultEqualityCheck` that clears the cache mid-search behaves as before
+    // instead of walking off the end of a replaced array.
+    const currentEntries = entries
+    const { length } = currentEntries
+
+    for (let i = 0; i < length; i++) {
+      const entry = currentEntries[i]
+
+      if (resultEqualityCheck(entry.value, value)) {
+        return entry
+      }
+    }
+
+    return undefined
   }
 
   function clear() {
     entries = []
   }
 
-  return { get, put, getEntries, clear }
+  return { get, put, findMatchingEntry, clear }
 }
 
 /**
@@ -218,9 +255,9 @@ export function lruMemoize<Func extends AnyFunction>(
       resultsCount++
 
       if (resultEqualityCheck) {
-        const entries = cache.getEntries()
-        const matchingEntry = entries.find(entry =>
-          resultEqualityCheck(entry.value as ReturnType<Func>, value)
+        const matchingEntry = cache.findMatchingEntry(
+          value,
+          resultEqualityCheck as EqualityFn
         )
 
         if (matchingEntry) {


### PR DESCRIPTION
This PR:

- Rewrites some of the cache lookups in `lruMemoize` to cut down on allocations and comparisons
  - Changes the `Cache` interface from `getEntries` to `findMatchingEntry`, which simplifies the usage


Supersedes #748 